### PR TITLE
Configurable proxy image + Kafka startup guard fix (v1.4.3-beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to LineSpec will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3-beta] - 2026-04-14
+
+### Added (Beta)
+
+- **Configurable proxy Docker image** ([prov-2026-557f393c](./provenance/prov-2026-557f393c.yml)) - New `proxy_image` field under `infrastructure` in `.linespec.yml` lets teams point proxies at a custom image instead of the default `linespec:latest`. Useful for CI/CD pipelines, private registries, and machines that don't have the image built locally.
+
+### Fixed (Beta)
+
+- **Kafka proxy startup now gated on `infrastructure.kafka`** ([prov-2026-557f393c](./provenance/prov-2026-557f393c.yml)) - The Kafka proxy container was previously started whenever a test used a `RECEIVE EVENT:` trigger, regardless of the `infrastructure.kafka` flag. It now respects the flag, consistent with all other proxy types (PostgreSQL, MySQL, HTTP, Redis, gRPC).
+
+### Related Provenance Records
+
+- [prov-2026-557f393c](./provenance/prov-2026-557f393c.yml) - Configurable proxy image name and Kafka proxy startup guard
+
 ## [1.4.1-beta] - 2026-04-13
 
 ### Added (Beta)

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ database:
 infrastructure:
   database: true
   kafka: false
+  proxy_image: "linespec:latest"  # Docker image for protocol proxies (default: linespec:latest)
 
 # Container naming configuration (optional)
 container_naming:

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -264,11 +264,12 @@ func substituteTemplate(template string, params ContainerNameParams) string {
 
 // InfrastructureConfig defines required infrastructure
 type InfrastructureConfig struct {
-	Kafka      bool `yaml:"kafka"`
-	Database   bool `yaml:"database"`
-	Redis      bool `yaml:"redis"`
-	GRPC       bool `yaml:"grpc"`
-	ExternalDB bool `yaml:"external_db"` // Don't manage DB, service has its own
+	Kafka      bool   `yaml:"kafka"`
+	Database   bool   `yaml:"database"`
+	Redis      bool   `yaml:"redis"`
+	GRPC       bool   `yaml:"grpc"`
+	ExternalDB bool   `yaml:"external_db"`  // Don't manage DB, service has its own
+	ProxyImage string `yaml:"proxy_image"`   // Docker image for protocol proxies (default: linespec:latest)
 }
 
 // LineSpecConfig is the root configuration structure

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -631,6 +631,13 @@ func (r *testRunner) run(ctx context.Context, specPath string) error {
 	}
 	r.config = serviceConfig
 
+	// Resolve proxy image — configurable so teams can point at a private registry or
+	// a pinned version without rebuilding from source on every machine.
+	proxyImage := serviceConfig.Infrastructure.ProxyImage
+	if proxyImage == "" {
+		proxyImage = "linespec:latest"
+	}
+
 	// Populate resolver with service environment variables
 	// This allows ${VAR_NAME} in .linespec files to reference values from .linespec.yml
 	for k, v := range serviceConfig.Service.Environment {
@@ -773,7 +780,7 @@ func (r *testRunner) run(ctx context.Context, specPath string) error {
 				}
 
 				_, err = r.suite.orch.StartContainer(ctx, &container.Config{
-					Image: "linespec:latest",
+					Image: proxyImage,
 					Cmd:   pgProxyCmd,
 					ExposedPorts: map[nat.Port]struct{}{
 						nat.Port(dbPort + "/tcp"): {},
@@ -830,7 +837,7 @@ func (r *testRunner) run(ctx context.Context, specPath string) error {
 
 				mysqlProxyContainerName := r.suite.containerNaming.GetProxyContainer(config.ContainerNameParams{SpecName: spec.Name, Type: "db"})
 				_, err = r.suite.orch.StartContainer(ctx, &container.Config{
-					Image: "linespec:latest",
+					Image: proxyImage,
 					Cmd:   mysqlProxyCmd,
 					ExposedPorts: map[nat.Port]struct{}{
 						nat.Port("8081/tcp"): {}, // Verification sidecar port
@@ -914,7 +921,7 @@ func (r *testRunner) run(ctx context.Context, specPath string) error {
 
 		httpProxyContainerName = r.suite.containerNaming.GetProxyContainer(config.ContainerNameParams{SpecName: spec.Name, Type: "http"})
 		_, err = r.suite.orch.StartContainer(ctx, &container.Config{
-			Image: "linespec:latest",
+			Image: proxyImage,
 			Cmd:   httpProxyCmd,
 		}, &container.HostConfig{
 			Binds: []string{
@@ -982,9 +989,10 @@ func (r *testRunner) run(ctx context.Context, specPath string) error {
 	// Start Kafka interceptor for consumer-triggered tests.
 	// Uses a distinct alias ("kafka-proxy") so it doesn't conflict with the real Kafka
 	// container on the network. The app's KAFKA_BROKERS will point to this interceptor.
+	// Requires infrastructure.kafka: true, consistent with all other proxy types.
 	const kafkaProxyAlias = "kafka-proxy"
 	kafkaProxyContainerName := r.suite.containerNaming.GetProxyContainer(config.ContainerNameParams{SpecName: spec.Name, Type: "kafka"})
-	if spec.Receive.Channel == types.Event {
+	if serviceConfig.Infrastructure.Kafka && spec.Receive.Channel == types.Event {
 		kafkaProxyCmd := []string{
 			"proxy", "kafka", "0.0.0.0:9092", "unused",
 			r.suite.containerNaming.GetRegistryMountPath() + "/registry-" + spec.Name + ".json",
@@ -994,7 +1002,7 @@ func (r *testRunner) run(ctx context.Context, specPath string) error {
 			kafkaProxyCmd = append(kafkaProxyCmd, "--debug")
 		}
 		_, err = r.suite.orch.StartContainer(ctx, &container.Config{
-			Image: "linespec:latest",
+			Image: proxyImage,
 			Cmd:   kafkaProxyCmd,
 		}, &container.HostConfig{
 			Binds: []string{
@@ -1052,7 +1060,7 @@ func (r *testRunner) run(ctx context.Context, specPath string) error {
 			grpcProxyCmd = append(grpcProxyCmd, "--debug")
 		}
 		_, err = r.suite.orch.StartContainer(ctx, &container.Config{
-			Image: "linespec:latest",
+			Image: proxyImage,
 			Cmd:   grpcProxyCmd,
 			ExposedPorts: map[nat.Port]struct{}{
 				nat.Port("50051/tcp"): {},
@@ -1115,7 +1123,7 @@ func (r *testRunner) run(ctx context.Context, specPath string) error {
 			redisProxyCmd = append(redisProxyCmd, "--debug")
 		}
 		_, err = r.suite.orch.StartContainer(ctx, &container.Config{
-			Image: "linespec:latest",
+			Image: proxyImage,
 			Cmd:   redisProxyCmd,
 			ExposedPorts: map[nat.Port]struct{}{
 				nat.Port("6379/tcp"): {},

--- a/provenance/prov-2026-557f393c.yml
+++ b/provenance/prov-2026-557f393c.yml
@@ -1,0 +1,27 @@
+id: prov-2026-557f393c
+title: Configurable proxy image name and Kafka proxy startup guard
+status: open
+created_at: "2026-04-14"
+author: calebcowen@gmail.com
+intent: "Make the linespec proxy Docker image name configurable via .linespec.yml so users on other machines don't need to build from source. Fix Kafka proxy startup to require infrastructure.kafka: true, consistent with all other proxies."
+constraints:
+  - "Default proxy_image value must remain linespec:latest for backwards compatibility"
+  - "Kafka proxy startup fix must not affect tests that already have infrastructure.kafka set to true"
+affected_scope:
+  - pkg/config/types.go
+  - pkg/runner/runner.go
+  - LINESPEC.md
+  - CHANGELOG.md
+forbidden_scope: []
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs:
+  - path: pkg/config/types.go
+    type: implementation
+  - path: pkg/runner/runner.go
+    type: implementation
+associated_traces: []
+monitors: []
+tags: []

--- a/provenance/prov-2026-557f393c.yml
+++ b/provenance/prov-2026-557f393c.yml
@@ -1,6 +1,6 @@
 id: prov-2026-557f393c
 title: Configurable proxy image name and Kafka proxy startup guard
-status: open
+status: implemented
 created_at: "2026-04-14"
 author: calebcowen@gmail.com
 intent: "Make the linespec proxy Docker image name configurable via .linespec.yml so users on other machines don't need to build from source. Fix Kafka proxy startup to require infrastructure.kafka: true, consistent with all other proxies."
@@ -16,7 +16,7 @@ forbidden_scope: []
 supersedes: ""
 superseded_by: ""
 related: []
-sealed_at_sha: ""
+sealed_at_sha: 60c897ffa028c15bf100cf1961479a9cfe9c7e45
 associated_specs:
   - path: pkg/config/types.go
     type: implementation

--- a/provenance/prov-2026-557f393c.yml
+++ b/provenance/prov-2026-557f393c.yml
@@ -10,7 +10,7 @@ constraints:
 affected_scope:
   - pkg/config/types.go
   - pkg/runner/runner.go
-  - LINESPEC.md
+  - README.md
   - CHANGELOG.md
 forbidden_scope: []
 supersedes: ""


### PR DESCRIPTION
## Summary

- **Add `proxy_image` to `infrastructure` config** — teams can now set `proxy_image: ghcr.io/org/linespec:v1.4.3-beta` (or any image) in `.linespec.yml` instead of requiring `linespec:latest` to be built locally on every machine. Defaults to `linespec:latest` for backwards compatibility.
- **Fix Kafka proxy startup guard** — the Kafka proxy was previously started whenever a test used `RECEIVE EVENT:`, regardless of the `infrastructure.kafka` flag. It now requires `infrastructure.kafka: true`, consistent with all other proxy types (PostgreSQL, MySQL, HTTP, Redis, gRPC).

## Details

- `pkg/config/types.go` — `ProxyImage string \`yaml:"proxy_image"\`` added to `InfrastructureConfig`
- `pkg/runner/runner.go` — `proxyImage` local var derived from config (fallback: `"linespec:latest"`); all 6 hardcoded image strings replaced; Kafka startup guard updated
- `README.md` — `proxy_image` field documented in infrastructure config example
- `CHANGELOG.md` — v1.4.3-beta entry added

Provenance: [prov-2026-557f393c](./provenance/prov-2026-557f393c.yml)

## Test plan

- [x] `make build-beta` succeeds
- [x] `make test` passes (all packages green)
- [ ] Manually verify `proxy_image` override works with a custom image name
- [ ] Verify Kafka proxy does not start when `infrastructure.kafka: false` on a consumer test

🤖 Generated with [Claude Code](https://claude.com/claude-code)