### PR TITLE
Agent-guidance for provenance: computed next engine, configurable teeth, and Claude Code plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ user_tests.log
 linespec-report/
 
 **/.linespec/schema-cache.json
+**/.linespec/scope-index.json
 
 # Docker compose override (generated during test runs)
 .linespec-compose-override.yml

--- a/.linespec.yml
+++ b/.linespec.yml
@@ -9,6 +9,7 @@ provenance:
   commit_tag_required: true  # whether commits must reference a prov ID
   auto_affected_scope: true   # whether to auto-populate affected_scope from git diffs
   run_associated_specs_on_complete: true  # run associated_specs before committing a completion transition
+  overlap_specs_on_complete: warn         # block | warn | off — cross-record overlap teeth severity at completion (warn: failures are non-blocking FYIs, since the back-to-back linespec cascade is environmentally fragile)
   commit_on_status_change: true           # auto-commit after open, complete, or deprecate transitions
   embedding:                  # semantic search and audit configuration
     provider: voyage           # embedding API provider (voyage)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`linespec provenance next`** — computes the single correct next provenance action (create / open / add spec / commit / complete) with record IDs filled in. Supports ambient mode, `--files`/`--plan` for intent-aware planning, and `--json`. Cache-backed fast path.
+- **`linespec provenance govern`** — lists the active (open + implemented) records governing given files, excluding superseded/deprecated. Supports `--files`/`--json`. Cache-backed.
+- **`linespec provenance install-plugin`** — installs the Claude Code provenance plugin (embedded in the binary).
+- **Claude Code provenance plugin** (`plugins/provenance/`) — SessionStart next-action guidance, advisory per-edit governance (PreToolUse), commit-rejection remediation (PostToolUse), and a `/provenance-next` slash command. Installable via `install-plugin` or the Claude Code marketplace (`.claude-plugin/marketplace.json`). All hooks render from the `linespec provenance` engine.
+- **`overlap_specs_on_complete`** config key (`block`|`warn`|`off`, default `block`) — severity of the completion-time cross-record overlap teeth. `complete --force` does not bypass them; remote (`shared_repos`) records are excluded.
+- **Scope cache** (`.linespec/scope-index.json`, gitignored) — backs `next`/`govern` with sub-200ms per-file lookups; self-healing via a stat-based fingerprint, with fallback to the authoritative load.
+
+### Changed
+- **Provenance guidance now renders from one computed engine** — `linespec provenance next` and the reworded enforcement hints (stale-scope warning, commit-violation hint, locked-scope error) all render from a single `Advise` function, so the CLI, the skill, and the new Claude Code plugin never drift. Touching a governed file does not imply superseding it.
+
 ## [3.12.0] - 2026-06-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,9 @@ Every change must be documented by a provenance record. Records live in `provena
 ```bash
 linespec provenance search "<query>"        # semantic search (requires embeddings)
 linespec provenance context -f <file>       # which records govern a file
+linespec provenance next --plan <file>      # the computed next action for files you'll change
 ```
+`next` renders the correct next step (create / open / add spec / commit / complete) with record IDs filled in — touching a governed file does **not** require superseding it. `govern --files <file>` lists just the active (open + implemented) records governing a file. Both are cache-backed (`.linespec/scope-index.json`).
 
 **2. Create a blueprint record (draft).** This captures scope and success criteria:
 ```bash
@@ -102,6 +104,10 @@ linespec provenance complete --record prov-YYYY-XXXXXXXX
 - Before each implementation commit: `linespec provenance check --staged`
 - **Never use `--no-verify`** to skip git hooks
 - Draft records are for planning — freely edit all fields including `affected_scope` in draft mode
+
+**Completion-time overlap teeth.** When a record is completed, the sealed records whose scope it actually touches have their `associated_specs` run. `overlap_specs_on_complete` in `.linespec.yml` sets severity — `block` (default; roll back on failure), `warn` (failure is a non-blocking FYI), or `off` (skip). This repo runs `warn` because completing files like `commands.go`/`main_*.go` pulls in the whole `examples/*-linespecs` Docker matrix, which is environmentally fragile. `complete --force` does not bypass the teeth.
+
+**Claude Code plugin.** `linespec provenance install-plugin` installs hooks that render this guidance in-loop (session-start `next`, per-edit `govern`, commit-rejection remediation) plus a `/provenance-next` command. See `plugins/provenance/`.
 
 ## Architecture
 

--- a/LINESPEC.md
+++ b/LINESPEC.md
@@ -1582,6 +1582,7 @@ provenance:
   commit_tag_required: true              # require a record ID in commit messages
   auto_affected_scope: true              # auto-populate affected_scope from git diffs
   run_associated_specs_on_complete: true # run associated_specs on the open→implemented transition
+  overlap_specs_on_complete: block       # completion-time overlap teeth severity: block | warn | off
   commit_on_status_change: true          # auto-commit after open/complete/deprecate transitions
   manifest_url: ""                       # source manifest URL (set automatically by `linespec clone`)
 

--- a/PROVENANCE_RECORDS.md
+++ b/PROVENANCE_RECORDS.md
@@ -696,6 +696,45 @@ linespec provenance context --format json pkg/proxy/postgresql/proxy.go
 - Follows `supersedes` chains to show ancestry
 - Detects conflicts when multiple open records govern the same file
 
+### Next
+
+Compute the single correct **next provenance action** for the current state, with record IDs filled in. Rather than navigating by enforcement errors, ask the engine what to do:
+
+```bash
+# Ambient: reads staged + working-tree changes
+linespec provenance next
+
+# Intent-aware: plan governance for files you intend to change (before editing)
+linespec provenance next --files pkg/proxy/postgresql/proxy.go
+linespec provenance next --plan pkg/proxy/postgresql/proxy.go   # --plan is an alias for --files
+
+# Machine-readable output for hooks/agents
+linespec provenance next --json
+```
+
+**Options:**
+- `--files f1 f2 f3` / `--plan f1 f2 f3` - Files you intend to change (intent-aware planning)
+- `--json` - Machine-readable output
+- `-c, --config path` - Use custom config
+
+**Output:** one primary action — `create` a record, `open` a draft, add an `associated_spec`, commit tagged, complete the blueprint, or "nothing pending" — with the ready-to-run command. When records already govern your files, it tells you to create one new record and tag your commits with it (you do **not** need to supersede them). Cache-backed (see [scope cache](#scope-cache)) for a fast path.
+
+### Govern
+
+List the **active** records (open + implemented) that govern given files — excluding superseded/deprecated. This is the narrow, fast lookup the Claude Code plugin's per-edit hook uses; the full `context` command still shows history:
+
+```bash
+linespec provenance govern --files pkg/proxy/postgresql/proxy.go
+linespec provenance govern --files pkg/proxy/postgresql/proxy.go --json
+```
+
+**Options:**
+- `--files f1 f2 f3` - Files to look up governance for (positional args also accepted)
+- `--json` - Machine-readable output (`{files, governing:[{id,status}], next}`)
+- `-c, --config path` - Use custom config
+
+Cache-backed; never pays a full record load on a cache hit.
+
 ### Search (Semantic)
 
 Search provenance records by semantic similarity:
@@ -817,6 +856,35 @@ This installs two skills:
 
 Existing skill directories are overwritten silently. Both skills are always installed together.
 
+### Install Plugin (Claude Code)
+
+Install the Claude Code **provenance plugin**, which surfaces the advice engine inside the agent loop:
+
+```bash
+# Install to .claude/plugins/ (default)
+linespec provenance install-plugin
+
+# Override the target directory
+linespec provenance install-plugin --path path/to/plugins
+```
+
+The plugin ships three hooks (all rendering from `linespec provenance`, no duplicated logic):
+
+- **SessionStart** — injects the ambient `next` action so the agent starts each session knowing the next step.
+- **PreToolUse (Edit/Write)** — on the first edit of a governed file, advisorily notes the open record to tag (and a count of sealed records that also govern it); never blocks.
+- **PostToolUse (Bash)** — when a `git commit` is rejected on a provenance violation, surfaces the engine's exact remediation.
+
+It also bundles a `/provenance-next` slash command. The plugin is installable two ways: this `install-plugin` command (the plugin is embedded in the `linespec` binary), or the Claude Code marketplace via the bundled `.claude-plugin/marketplace.json`:
+
+```bash
+claude plugin marketplace add <repo>/plugins/provenance
+claude plugin install linespec-provenance@linespec
+```
+
+### Scope Cache
+
+`context`, `next`, and `govern` are backed by a scope cache at `.linespec/scope-index.json` — a compact projection of each record's governance fields plus a cheap stat-based fingerprint of the provenance directory. On a fingerprint match the per-file lookups skip the full record load (fast enough for a per-edit hook); on any mismatch or read error they fall back to the authoritative load. The cache is machine-specific (gitignored), self-healing, and safe to delete at any time — it simply rebuilds.
+
 ---
 
 ## Configuration
@@ -839,7 +907,11 @@ provenance:
   
   # Run associated_specs before allowing a completion-transition commit (default: false)
   run_associated_specs_on_complete: false
-  
+
+  # Severity of the completion-time cross-record overlap teeth: block|warn|off
+  # (default: block). Gated by run_associated_specs_on_complete above.
+  overlap_specs_on_complete: block
+
   # Additional directories to load records from (for monorepos)
   shared_repos:
     - examples/user-service/provenance
@@ -855,7 +927,18 @@ provenance:
 | `commit_tag_required` | bool | `false` | Require tags in commits |
 | `auto_affected_scope` | bool | `true` | Auto-populate scope |
 | `run_associated_specs_on_complete` | bool | `false` | Run specs on completion transition |
+| `overlap_specs_on_complete` | string | `block` | Completion-time overlap teeth severity: `block`\|`warn`\|`off` |
 | `shared_repos` | array | `[]` | Additional directories |
+
+#### `overlap_specs_on_complete`
+
+When a record is completed, the completion-time **overlap teeth** run the `associated_specs` of the already-implemented (sealed) records whose scope the change actually touches — verifying that those sealed behaviors still hold. This key sets the severity (it only applies when `run_associated_specs_on_complete` is enabled, the master switch):
+
+- **`block`** (default) — run the touched sealed records' specs; if any fails, roll the completion back atomically. This is the original behavior.
+- **`warn`** — run them, but a failure becomes a non-blocking FYI and the completion proceeds. Useful when the spec suite is environmentally fragile (e.g. flaky container startup) and a failure is more likely noise than a real regression.
+- **`off`** — skip the cross-record teeth entirely. The completing record's **own** `associated_specs` still run.
+
+Note: `complete --force` does **not** bypass the teeth — only this config key (and the master switch) controls them. Remote (`shared_repos`) records are never run as teeth against your local tree.
 
 ### Semantic Search Configuration
 

--- a/PROVENANCE_RECORD_SCHEMA.md
+++ b/PROVENANCE_RECORD_SCHEMA.md
@@ -282,7 +282,7 @@ associated_specs:
     run_command: python -m pytest --tb=short  # overrides default "pytest <path>"
 ```
 **Set by:** Author.  
-**Behavior:** The linter checks that each listed path exists on disk. At `strict` enforcement, an `open` record with no entries here is a lint error. At `warn`, it is a warning. At `none`, no check is performed beyond verifying that listed paths exist if any are provided. When `run_associated_specs_on_complete` is enabled in `.linespec.yml`, the pre-commit hook runs each spec whose `type` or `run_command` is set during the `open` → `implemented` transition.  
+**Behavior:** The linter checks that each listed path exists on disk. At `strict` enforcement, an `open` record with no entries here is a lint error. At `warn`, it is a warning. At `none`, no check is performed beyond verifying that listed paths exist if any are provided. When `run_associated_specs_on_complete` is enabled in `.linespec.yml`, the pre-commit hook runs each spec whose `type` or `run_command` is set during the `open` → `implemented` transition. At completion, the specs of already-sealed records whose scope the change actually touches are also run (the overlap "teeth"); `overlap_specs_on_complete` (`block`|`warn`|`off`, default `block`) sets that severity. See [PROVENANCE_RECORDS.md](./PROVENANCE_RECORDS.md#overlap_specs_on_complete).  
 **`run_command` template:** If the command string contains `{{path}}`, it is replaced with `spec.path`. Otherwise `spec.path` is appended as a trailing argument.  
 **Constraints:** Immutable after `implemented`. Specs with no `type` and no `run_command` are skipped (not an error) when the hook runs them.
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ linespec provenance lint            # Validate records
 linespec provenance status          # View status
 linespec provenance graph           # Render decision graph
 
+# Agent guidance
+linespec provenance next            # Compute the correct next provenance action
+linespec provenance govern          # List the active records governing given files
+linespec provenance context         # Show which records govern given files
+
 # Semantic search (requires embedding configuration)
 linespec provenance search          # Search by semantic similarity
 linespec provenance audit           # Audit changes against history
@@ -126,6 +131,7 @@ linespec provenance index           # Index records for search
 linespec provenance check           # Check commits for violations
 linespec provenance install-hooks   # Install git hooks
 linespec provenance install-skills  # Install all Claude Code skills (provenance + linespec-testing)
+linespec provenance install-plugin  # Install the Claude Code provenance plugin (hooks + slash command)
 
 # Lifecycle management
 linespec provenance lock-scope      # Lock scope to allowlist
@@ -243,6 +249,8 @@ provenance:
   enforcement: warn                  # none|warn|strict
   commit_tag_required: false         # Require IDs in commits
   auto_affected_scope: true           # Auto-populate from git
+  run_associated_specs_on_complete: false  # Run associated_specs on completion
+  overlap_specs_on_complete: block   # Overlap teeth severity: block|warn|off
   shared_repos: []                    # Additional directories (monorepos)
   
   # Semantic search configuration (optional - supports voyage or openai)

--- a/cmd/linespec/main_beta.go
+++ b/cmd/linespec/main_beta.go
@@ -563,6 +563,15 @@ func runProvenance() {
 	// Get repo root
 	repoRoot, _ := os.Getwd()
 
+	// Fast path: `next` can be served from the cached scope index without the full
+	// record load, keeping it cheap enough for a per-edit hook. Falls through to the
+	// heavy, authoritative path on any cache miss/staleness (prov-2026-007c8893).
+	if subcommand == "next" {
+		if provenance.TryNextFromCache(cfg, repoRoot, os.Stdout, true, parseNextOptions(args)) {
+			return
+		}
+	}
+
 	// Create embedder client if configured
 	var embedder *embeddings.Client
 	if cfg.Embedding != nil {

--- a/cmd/linespec/main_beta.go
+++ b/cmd/linespec/main_beta.go
@@ -823,6 +823,12 @@ func runProvenance() {
 			logger.Error("Failed to install skills: %v", err)
 			os.Exit(1)
 		}
+	case "install-plugin":
+		opts := parseInstallPluginOptions(args)
+		if err := cmds.InstallPlugin(opts); err != nil {
+			logger.Error("Failed to install plugin: %v", err)
+			os.Exit(1)
+		}
 	case "--help", "-h":
 		printProvenanceUsage()
 	default:
@@ -1001,6 +1007,32 @@ func parseInstallSkillsOptions(args []string) provenance.InstallSkillsOptions {
 
 Options:
   --path dir     Target directory relative to repo root (default: .claude/skills)
+  --help         Show this help message`)
+			os.Exit(0)
+		}
+	}
+
+	return opts
+}
+
+func parseInstallPluginOptions(args []string) provenance.InstallPluginOptions {
+	opts := provenance.InstallPluginOptions{}
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--path":
+			if i+1 < len(args) {
+				opts.Path = args[i+1]
+				i++
+			}
+		case "--help", "-h":
+			logger.Info(`Usage: linespec provenance install-plugin [options]
+
+Installs the Claude Code provenance plugin (session-start guidance, per-edit
+governance, commit remediation) into a target config directory.
+
+Options:
+  --path dir     Target plugins directory relative to repo root (default: .claude/plugins)
   --help         Show this help message`)
 			os.Exit(0)
 		}

--- a/cmd/linespec/main_beta.go
+++ b/cmd/linespec/main_beta.go
@@ -729,6 +729,15 @@ func runProvenance() {
 		if err := cmds.Context(opts); err != nil {
 			os.Exit(1)
 		}
+	case "next":
+		opts := parseNextOptions(args)
+		if err := reloadConfigIfNeeded(&cfg, &cmds, opts.ConfigFile, repoRoot); err != nil {
+			logger.Error("Failed to reload config: %v", err)
+			os.Exit(1)
+		}
+		if err := cmds.Next(opts); err != nil {
+			os.Exit(1)
+		}
 	case "search":
 		opts := parseSearchOptions(args)
 		if err := reloadConfigIfNeeded(&cfg, &cmds, opts.ConfigFile, repoRoot); err != nil {
@@ -1340,6 +1349,62 @@ Options:
 		default:
 			// If not a flag, treat as positional file argument
 			if !strings.HasPrefix(args[i], "--") && !strings.HasPrefix(args[i], "-") {
+				opts.Files = append(opts.Files, args[i])
+			}
+		}
+	}
+
+	return opts
+}
+
+// parseNextOptions parses flags for `linespec provenance next`. Files may be given
+// positionally, via --files, or via the --plan alias. --json selects JSON output.
+func parseNextOptions(args []string) provenance.NextOptions {
+	opts := provenance.NextOptions{}
+
+	collectFiles := func(start int) int {
+		last := start
+		for j := start + 1; j < len(args); j++ {
+			if strings.HasPrefix(args[j], "-") {
+				return j - 1
+			}
+			opts.Files = append(opts.Files, args[j])
+			last = j
+		}
+		return last
+	}
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--files", "--plan":
+			i = collectFiles(i)
+		case "--json":
+			opts.Format = "json"
+		case "--format":
+			if i+1 < len(args) {
+				opts.Format = args[i+1]
+				i++
+			}
+		case "-c", "--config":
+			if i+1 < len(args) {
+				opts.ConfigFile = args[i+1]
+				i++
+			}
+		case "--help", "-h":
+			logger.Info(`Usage: linespec provenance next [options] [files...]
+
+Computes the single correct next provenance action for the current state.
+With no files, reads staged + working-tree changes. With files, plans ahead.
+
+Options:
+  --files f1 f2 f3          Files you intend to change (plan before editing)
+  --plan f1 f2 f3           Alias for --files
+  --json                    Machine-readable output (for hooks/agents)
+  -c, --config path         Path to custom .linespec.yml file
+  --help                    Show this help message`)
+			os.Exit(0)
+		default:
+			if !strings.HasPrefix(args[i], "-") {
 				opts.Files = append(opts.Files, args[i])
 			}
 		}

--- a/cmd/linespec/main_beta.go
+++ b/cmd/linespec/main_beta.go
@@ -571,6 +571,11 @@ func runProvenance() {
 			return
 		}
 	}
+	if subcommand == "govern" {
+		if provenance.TryGovernFromCache(cfg, repoRoot, os.Stdout, true, parseGovernOptions(args)) {
+			return
+		}
+	}
 
 	// Create embedder client if configured
 	var embedder *embeddings.Client
@@ -745,6 +750,15 @@ func runProvenance() {
 			os.Exit(1)
 		}
 		if err := cmds.Next(opts); err != nil {
+			os.Exit(1)
+		}
+	case "govern":
+		opts := parseGovernOptions(args)
+		if err := reloadConfigIfNeeded(&cfg, &cmds, opts.ConfigFile, repoRoot); err != nil {
+			logger.Error("Failed to reload config: %v", err)
+			os.Exit(1)
+		}
+		if err := cmds.Govern(opts); err != nil {
 			os.Exit(1)
 		}
 	case "search":
@@ -1410,6 +1424,63 @@ Options:
   --files f1 f2 f3          Files you intend to change (plan before editing)
   --plan f1 f2 f3           Alias for --files
   --json                    Machine-readable output (for hooks/agents)
+  -c, --config path         Path to custom .linespec.yml file
+  --help                    Show this help message`)
+			os.Exit(0)
+		default:
+			if !strings.HasPrefix(args[i], "-") {
+				opts.Files = append(opts.Files, args[i])
+			}
+		}
+	}
+
+	return opts
+}
+
+// parseGovernOptions parses flags for `linespec provenance govern` — the active-only
+// per-file governance lookup. Files may be positional or via --files; --json selects
+// JSON output (the hook-facing shape).
+func parseGovernOptions(args []string) provenance.GovernOptions {
+	opts := provenance.GovernOptions{}
+
+	collectFiles := func(start int) int {
+		last := start
+		for j := start + 1; j < len(args); j++ {
+			if strings.HasPrefix(args[j], "-") {
+				return j - 1
+			}
+			opts.Files = append(opts.Files, args[j])
+			last = j
+		}
+		return last
+	}
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--files":
+			i = collectFiles(i)
+		case "--json":
+			opts.Format = "json"
+		case "--format":
+			if i+1 < len(args) {
+				opts.Format = args[i+1]
+				i++
+			}
+		case "-c", "--config":
+			if i+1 < len(args) {
+				opts.ConfigFile = args[i+1]
+				i++
+			}
+		case "--help", "-h":
+			logger.Info(`Usage: linespec provenance govern [options] [files...]
+
+Lists the ACTIVE provenance records (open + implemented) that govern the given
+files — excluding superseded/deprecated. Cache-backed and fast; intended for the
+Claude Code plugin's per-edit hook.
+
+Options:
+  --files f1 f2 f3          Files to look up governance for
+  --json                    Machine-readable output (for hooks)
   -c, --config path         Path to custom .linespec.yml file
   --help                    Show this help message`)
 			os.Exit(0)

--- a/cmd/linespec/main_beta.go
+++ b/cmd/linespec/main_beta.go
@@ -838,6 +838,7 @@ func loadProvenanceConfigFromFile(filePath string) *provenance.ProvenanceConfig 
 			cfg.CommitTagRequired = fullConfig.Provenance.CommitTagRequired
 			cfg.AutoAffectedScope = fullConfig.Provenance.AutoAffectedScope
 			cfg.RunAssociatedSpecsOnComplete = fullConfig.Provenance.RunAssociatedSpecsOnComplete
+			cfg.OverlapSpecsOnComplete = fullConfig.Provenance.OverlapSpecsOnComplete
 			cfg.CommitOnStatusChange = fullConfig.Provenance.CommitOnStatusChange
 			cfg.SharedRepos = fullConfig.Provenance.SharedRepos
 			cfg.CacheTTLMinutes = fullConfig.Provenance.CacheTTLMinutes

--- a/cmd/linespec/main_stable.go
+++ b/cmd/linespec/main_stable.go
@@ -1027,6 +1027,15 @@ func runProvenance() {
 	// Get repo root
 	repoRoot, _ := os.Getwd()
 
+	// Fast path: `next` can be served from the cached scope index without the full
+	// record load, keeping it cheap enough for a per-edit hook. Falls through to the
+	// heavy, authoritative path on any cache miss/staleness (prov-2026-007c8893).
+	if subcommand == "next" {
+		if provenance.TryNextFromCache(cfg, repoRoot, os.Stdout, true, parseNextOptions(args)) {
+			return
+		}
+	}
+
 	// Create embedder client if configured
 	var embedder *embeddings.Client
 	if cfg.Embedding != nil {

--- a/cmd/linespec/main_stable.go
+++ b/cmd/linespec/main_stable.go
@@ -1333,6 +1333,7 @@ func loadProvenanceConfigFromFile(filePath string) *provenance.ProvenanceConfig 
 			cfg.CommitTagRequired = fullConfig.Provenance.CommitTagRequired
 			cfg.AutoAffectedScope = fullConfig.Provenance.AutoAffectedScope
 			cfg.RunAssociatedSpecsOnComplete = fullConfig.Provenance.RunAssociatedSpecsOnComplete
+			cfg.OverlapSpecsOnComplete = fullConfig.Provenance.OverlapSpecsOnComplete
 			cfg.CommitOnStatusChange = fullConfig.Provenance.CommitOnStatusChange
 			cfg.SharedRepos = fullConfig.Provenance.SharedRepos
 			cfg.CacheTTLMinutes = fullConfig.Provenance.CacheTTLMinutes

--- a/cmd/linespec/main_stable.go
+++ b/cmd/linespec/main_stable.go
@@ -1193,6 +1193,15 @@ func runProvenance() {
 		if err := cmds.Context(opts); err != nil {
 			os.Exit(1)
 		}
+	case "next":
+		opts := parseNextOptions(args)
+		if err := reloadConfigIfNeeded(&cfg, &cmds, opts.ConfigFile, repoRoot); err != nil {
+			logger.Error("Failed to reload config: %v", err)
+			os.Exit(1)
+		}
+		if err := cmds.Next(opts); err != nil {
+			os.Exit(1)
+		}
 	case "search":
 		opts := parseSearchOptions(args)
 		if err := reloadConfigIfNeeded(&cfg, &cmds, opts.ConfigFile, repoRoot); err != nil {
@@ -1888,6 +1897,62 @@ Options:
 		default:
 			// If not a flag, treat as positional file argument
 			if !strings.HasPrefix(args[i], "--") && !strings.HasPrefix(args[i], "-") {
+				opts.Files = append(opts.Files, args[i])
+			}
+		}
+	}
+
+	return opts
+}
+
+// parseNextOptions parses flags for `linespec provenance next`. Files may be given
+// positionally, via --files, or via the --plan alias. --json selects JSON output.
+func parseNextOptions(args []string) provenance.NextOptions {
+	opts := provenance.NextOptions{}
+
+	collectFiles := func(start int) int {
+		last := start
+		for j := start + 1; j < len(args); j++ {
+			if strings.HasPrefix(args[j], "-") {
+				return j - 1
+			}
+			opts.Files = append(opts.Files, args[j])
+			last = j
+		}
+		return last
+	}
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--files", "--plan":
+			i = collectFiles(i)
+		case "--json":
+			opts.Format = "json"
+		case "--format":
+			if i+1 < len(args) {
+				opts.Format = args[i+1]
+				i++
+			}
+		case "-c", "--config":
+			if i+1 < len(args) {
+				opts.ConfigFile = args[i+1]
+				i++
+			}
+		case "--help", "-h":
+			logger.Info(`Usage: linespec provenance next [options] [files...]
+
+Computes the single correct next provenance action for the current state.
+With no files, reads staged + working-tree changes. With files, plans ahead.
+
+Options:
+  --files f1 f2 f3          Files you intend to change (plan before editing)
+  --plan f1 f2 f3           Alias for --files
+  --json                    Machine-readable output (for hooks/agents)
+  -c, --config path         Path to custom .linespec.yml file
+  --help                    Show this help message`)
+			os.Exit(0)
+		default:
+			if !strings.HasPrefix(args[i], "-") {
 				opts.Files = append(opts.Files, args[i])
 			}
 		}

--- a/cmd/linespec/main_stable.go
+++ b/cmd/linespec/main_stable.go
@@ -1318,6 +1318,12 @@ func runProvenance() {
 			logger.Error("Failed to install skills: %v", err)
 			os.Exit(1)
 		}
+	case "install-plugin":
+		opts := parseInstallPluginOptions(args)
+		if err := cmds.InstallPlugin(opts); err != nil {
+			logger.Error("Failed to install plugin: %v", err)
+			os.Exit(1)
+		}
 	case "--help", "-h":
 		printProvenanceUsage()
 	default:
@@ -1540,6 +1546,32 @@ func parseInstallSkillsOptions(args []string) provenance.InstallSkillsOptions {
 
 Options:
   --path dir     Target directory relative to repo root (default: .claude/skills)
+  --help         Show this help message`)
+			os.Exit(0)
+		}
+	}
+
+	return opts
+}
+
+func parseInstallPluginOptions(args []string) provenance.InstallPluginOptions {
+	opts := provenance.InstallPluginOptions{}
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--path":
+			if i+1 < len(args) {
+				opts.Path = args[i+1]
+				i++
+			}
+		case "--help", "-h":
+			logger.Info(`Usage: linespec provenance install-plugin [options]
+
+Installs the Claude Code provenance plugin (session-start guidance, per-edit
+governance, commit remediation) into a target config directory.
+
+Options:
+  --path dir     Target plugins directory relative to repo root (default: .claude/plugins)
   --help         Show this help message`)
 			os.Exit(0)
 		}

--- a/cmd/linespec/main_stable.go
+++ b/cmd/linespec/main_stable.go
@@ -1035,6 +1035,11 @@ func runProvenance() {
 			return
 		}
 	}
+	if subcommand == "govern" {
+		if provenance.TryGovernFromCache(cfg, repoRoot, os.Stdout, true, parseGovernOptions(args)) {
+			return
+		}
+	}
 
 	// Create embedder client if configured
 	var embedder *embeddings.Client
@@ -1209,6 +1214,15 @@ func runProvenance() {
 			os.Exit(1)
 		}
 		if err := cmds.Next(opts); err != nil {
+			os.Exit(1)
+		}
+	case "govern":
+		opts := parseGovernOptions(args)
+		if err := reloadConfigIfNeeded(&cfg, &cmds, opts.ConfigFile, repoRoot); err != nil {
+			logger.Error("Failed to reload config: %v", err)
+			os.Exit(1)
+		}
+		if err := cmds.Govern(opts); err != nil {
 			os.Exit(1)
 		}
 	case "search":
@@ -1958,6 +1972,63 @@ Options:
   --files f1 f2 f3          Files you intend to change (plan before editing)
   --plan f1 f2 f3           Alias for --files
   --json                    Machine-readable output (for hooks/agents)
+  -c, --config path         Path to custom .linespec.yml file
+  --help                    Show this help message`)
+			os.Exit(0)
+		default:
+			if !strings.HasPrefix(args[i], "-") {
+				opts.Files = append(opts.Files, args[i])
+			}
+		}
+	}
+
+	return opts
+}
+
+// parseGovernOptions parses flags for `linespec provenance govern` — the active-only
+// per-file governance lookup. Files may be positional or via --files; --json selects
+// JSON output (the hook-facing shape).
+func parseGovernOptions(args []string) provenance.GovernOptions {
+	opts := provenance.GovernOptions{}
+
+	collectFiles := func(start int) int {
+		last := start
+		for j := start + 1; j < len(args); j++ {
+			if strings.HasPrefix(args[j], "-") {
+				return j - 1
+			}
+			opts.Files = append(opts.Files, args[j])
+			last = j
+		}
+		return last
+	}
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--files":
+			i = collectFiles(i)
+		case "--json":
+			opts.Format = "json"
+		case "--format":
+			if i+1 < len(args) {
+				opts.Format = args[i+1]
+				i++
+			}
+		case "-c", "--config":
+			if i+1 < len(args) {
+				opts.ConfigFile = args[i+1]
+				i++
+			}
+		case "--help", "-h":
+			logger.Info(`Usage: linespec provenance govern [options] [files...]
+
+Lists the ACTIVE provenance records (open + implemented) that govern the given
+files — excluding superseded/deprecated. Cache-backed and fast; intended for the
+Claude Code plugin's per-edit hook.
+
+Options:
+  --files f1 f2 f3          Files to look up governance for
+  --json                    Machine-readable output (for hooks)
   -c, --config path         Path to custom .linespec.yml file
   --help                    Show this help message`)
 			os.Exit(0)

--- a/docs/index.html
+++ b/docs/index.html
@@ -234,6 +234,14 @@ tags:
                         <p>Render the decision graph</p>
                     </div>
                     <div class="cli-card">
+                        <code>linespec provenance next</code>
+                        <p>Compute the correct next provenance action</p>
+                    </div>
+                    <div class="cli-card">
+                        <code>linespec provenance govern</code>
+                        <p>List the active records governing given files</p>
+                    </div>
+                    <div class="cli-card">
                         <code>linespec provenance search</code>
                         <p>Semantic search across records</p>
                     </div>
@@ -248,6 +256,10 @@ tags:
                     <div class="cli-card">
                         <code>linespec provenance install-skills</code>
                         <p>Install provenance + linespec-testing skills for Claude Code / AI agents</p>
+                    </div>
+                    <div class="cli-card">
+                        <code>linespec provenance install-plugin</code>
+                        <p>Install the Claude Code provenance plugin (hooks + slash command)</p>
                     </div>
                 </div>
             </div>

--- a/docs/linespec.html
+++ b/docs/linespec.html
@@ -1361,6 +1361,7 @@ user_id: 123</code></pre>
   commit_tag_required: true  # Commits must reference a provenance record ID
   auto_affected_scope: true  # Auto-populate affected_scope from git diffs
   run_associated_specs_on_complete: true  # Run associated_specs on open→implemented
+  overlap_specs_on_complete: block        # Completion-time overlap teeth severity: block|warn|off
   commit_on_status_change: true           # Auto-commit after open/complete/deprecate
   manifest_url: ""                         # Source manifest URL (set by `linespec clone`)
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -127,6 +127,11 @@ linespec provenance lint            # Validate records
 linespec provenance status          # View status
 linespec provenance graph           # Render decision graph
 
+# Agent guidance
+linespec provenance next            # Compute the correct next provenance action
+linespec provenance govern          # List the active records governing given files
+linespec provenance context         # Show which records govern given files
+
 # Semantic search (requires embedding configuration)
 linespec provenance search          # Search by semantic similarity
 linespec provenance audit           # Audit changes against history
@@ -136,6 +141,7 @@ linespec provenance index           # Index records for search
 linespec provenance check           # Check commits for violations
 linespec provenance install-hooks   # Install git hooks
 linespec provenance install-skills  # Install all Claude Code skills (provenance + linespec-testing)
+linespec provenance install-plugin  # Install the Claude Code provenance plugin (hooks + slash command)
 
 # Lifecycle management
 linespec provenance lock-scope      # Lock scope to allowlist
@@ -253,6 +259,8 @@ provenance:
   enforcement: warn                  # none|warn|strict
   commit_tag_required: false         # Require IDs in commits
   auto_affected_scope: true           # Auto-populate from git
+  run_associated_specs_on_complete: false  # Run associated_specs on completion
+  overlap_specs_on_complete: block   # Overlap teeth severity: block|warn|off
   shared_repos: []                    # Additional directories (monorepos)
   
   # Semantic search configuration (optional - supports voyage or openai)
@@ -1103,6 +1111,30 @@ linespec provenance context --format json pkg/proxy/postgresql/proxy.go
 - Follows `supersedes` chains to show ancestry
 - Detects conflicts when multiple open records govern the same file
 
+### Next
+
+Compute the single correct **next provenance action** for the current state, with record IDs filled in:
+
+```bash
+linespec provenance next                                          # ambient (staged + working-tree changes)
+linespec provenance next --files pkg/proxy/postgresql/proxy.go    # intent-aware planning
+linespec provenance next --plan pkg/proxy/postgresql/proxy.go     # --plan is an alias for --files
+linespec provenance next --json                                   # machine-readable (hooks/agents)
+```
+
+Output is one primary action — `create` / `open` / add `associated_spec` / commit tagged / `complete` / "nothing pending" — with the ready-to-run command. When records already govern your files, it tells you to create one new record and tag your commits with it; you do **not** need to supersede them. Cache-backed (see Scope Cache).
+
+### Govern
+
+List the **active** records (open + implemented) that govern given files — excluding superseded/deprecated. This is the narrow, fast lookup the Claude Code plugin's per-edit hook uses; the full `context` command still shows history:
+
+```bash
+linespec provenance govern --files pkg/proxy/postgresql/proxy.go
+linespec provenance govern --files pkg/proxy/postgresql/proxy.go --json
+```
+
+`--json` emits `{files, governing:[{id,status}], next}`. Cache-backed; never pays a full record load on a cache hit.
+
 ### Search (Semantic)
 
 Search provenance records by semantic similarity:
@@ -1224,6 +1256,26 @@ This installs two skills:
 
 Existing skill directories are overwritten silently. Both skills are always installed together.
 
+### Install Plugin (Claude Code)
+
+Install the Claude Code **provenance plugin**, which surfaces the advice engine inside the agent loop:
+
+```bash
+linespec provenance install-plugin                     # install to .claude/plugins/ (default)
+linespec provenance install-plugin --path path/to/plugins
+```
+
+The plugin ships three hooks (all rendering from `linespec provenance`, no duplicated logic): **SessionStart** injects the ambient `next` action; **PreToolUse (Edit/Write)** advisorily notes the open record to tag on the first edit of a governed file (never blocks); **PostToolUse (Bash)** surfaces the engine's remediation when a `git commit` is rejected on a provenance violation. It also bundles a `/provenance-next` slash command. Installable via this command (the plugin is embedded in the binary) or the Claude Code marketplace:
+
+```bash
+claude plugin marketplace add <repo>/plugins/provenance
+claude plugin install linespec-provenance@linespec
+```
+
+### Scope Cache
+
+`context`, `next`, and `govern` are backed by a scope cache at `.linespec/scope-index.json` — a compact projection of each record's governance fields plus a cheap stat-based fingerprint of the provenance directory. On a fingerprint match the per-file lookups skip the full record load; on any mismatch or read error they fall back to the authoritative load. The cache is machine-specific (gitignored), self-healing, and safe to delete at any time.
+
 ---
 
 ## Configuration
@@ -1246,7 +1298,11 @@ provenance:
   
   # Run associated_specs before allowing a completion-transition commit (default: false)
   run_associated_specs_on_complete: false
-  
+
+  # Severity of the completion-time cross-record overlap teeth: block|warn|off
+  # (default: block). Gated by run_associated_specs_on_complete above.
+  overlap_specs_on_complete: block
+
   # Additional directories to load records from (for monorepos)
   shared_repos:
     - examples/user-service/provenance
@@ -1262,7 +1318,10 @@ provenance:
 | `commit_tag_required` | bool | `false` | Require tags in commits |
 | `auto_affected_scope` | bool | `true` | Auto-populate scope |
 | `run_associated_specs_on_complete` | bool | `false` | Run specs on completion transition |
+| `overlap_specs_on_complete` | string | `block` | Completion-time overlap teeth severity: `block`\|`warn`\|`off` |
 | `shared_repos` | array | `[]` | Additional directories |
+
+When a record is completed, the **overlap teeth** run the `associated_specs` of the already-sealed records whose scope the change actually touches. `overlap_specs_on_complete` sets the severity (it applies only when `run_associated_specs_on_complete` is enabled): **`block`** (default) rolls the completion back on a spec failure; **`warn`** turns a failure into a non-blocking FYI and proceeds (useful when the suite is environmentally fragile); **`off`** skips the cross-record teeth entirely (the completing record's own specs still run). `complete --force` does **not** bypass the teeth, and remote (`shared_repos`) records are never run against your local tree.
 
 ### Semantic Search Configuration
 
@@ -3503,6 +3562,7 @@ provenance:
   commit_tag_required: true              # require a record ID in commit messages
   auto_affected_scope: true              # auto-populate affected_scope from git diffs
   run_associated_specs_on_complete: true # run associated_specs on the open→implemented transition
+  overlap_specs_on_complete: block       # completion-time overlap teeth severity: block | warn | off
   commit_on_status_change: true          # auto-commit after open/complete/deprecate transitions
   manifest_url: ""                       # source manifest URL (set automatically by `linespec clone`)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,7 +11,8 @@
 
 ## For AI agents working in a LineSpec repo
 
-- [Provenance workflow & scope enforcement](https://linespec.dev/provenance.html): How to make a change without getting blocked — investigate with `provenance context -f <file>`, create ONE record covering your files, set its `affected_scope`, add a proof spec, open, commit tagged, complete. The scope check only validates the record you tag; overlapping records (even implemented ones) do not need to be superseded. Never use `--no-verify`; never relax enforcement to get unblocked.
+- [Provenance workflow & scope enforcement](https://linespec.dev/provenance.html): How to make a change without getting blocked — investigate with `provenance context -f <file>` (or `provenance next --plan <file>` for the computed next action), create ONE record covering your files, set its `affected_scope`, add a proof spec, open, commit tagged, complete. The scope check only validates the record you tag; overlapping records (even implemented ones) do not need to be superseded. Never use `--no-verify`; never relax enforcement to get unblocked.
+- [Engine-driven guidance](https://linespec.dev/provenance.html): `provenance next` computes the correct next action (create/open/spec/commit/complete) with IDs filled in; `provenance govern --files <f>` lists the active records governing a file. The Claude Code plugin (`provenance install-plugin`) surfaces this in the agent loop via SessionStart/PreToolUse/commit hooks.
 
 ## Full text
 

--- a/docs/provenance.html
+++ b/docs/provenance.html
@@ -807,6 +807,56 @@ linespec provenance context --format json pkg/proxy/postgresql/proxy.go</code></
                         <li>Detects conflicts when multiple open records govern the same file</li>
                     </ul>
 
+                    <h3>Next</h3>
+                    <p>Compute the single correct <strong>next provenance action</strong> for the current state, with record IDs filled in — instead of navigating by enforcement errors, ask the engine what to do:</p>
+                    <div class="code-block">
+                        <div class="code-header">
+                            <span>Terminal</span>
+                            <button class="copy-btn" aria-label="Copy code">
+                                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                                    <path d="M4 4v8h8V4H4zM2 2h12v12H2V2z" stroke="currentColor" stroke-width="1.5"/>
+                                </svg>
+                            </button>
+                        </div>
+                        <pre><code># Ambient: reads staged + working-tree changes
+linespec provenance next
+
+# Intent-aware: plan governance for files you intend to change
+linespec provenance next --files pkg/proxy/postgresql/proxy.go
+linespec provenance next --plan pkg/proxy/postgresql/proxy.go   # --plan is an alias for --files
+
+# Machine-readable output for hooks/agents
+linespec provenance next --json</code></pre>
+                    </div>
+                    <p><strong>Options:</strong></p>
+                    <ul>
+                        <li><code>--files f1 f2 f3</code> / <code>--plan f1 f2 f3</code> - Files you intend to change (intent-aware planning)</li>
+                        <li><code>--json</code> - Machine-readable output</li>
+                        <li><code>-c, --config path</code> - Use custom config</li>
+                    </ul>
+                    <p><strong>Output:</strong> one primary action — <code>create</code>, <code>open</code>, add an <code>associated_spec</code>, commit tagged, <code>complete</code>, or "nothing pending" — with the ready-to-run command. When records already govern your files, it tells you to create one new record and tag your commits with it; you do <strong>not</strong> need to supersede them. Cache-backed for a fast path.</p>
+
+                    <h3>Govern</h3>
+                    <p>List the <strong>active</strong> records (open + implemented) that govern given files — excluding superseded/deprecated. This is the narrow, fast lookup the Claude Code plugin's per-edit hook uses; the full <code>context</code> command still shows history.</p>
+                    <div class="code-block">
+                        <div class="code-header">
+                            <span>Terminal</span>
+                            <button class="copy-btn" aria-label="Copy code">
+                                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                                    <path d="M4 4v8h8V4H4zM2 2h12v12H2V2z" stroke="currentColor" stroke-width="1.5"/>
+                                </svg>
+                            </button>
+                        </div>
+                        <pre><code>linespec provenance govern --files pkg/proxy/postgresql/proxy.go
+linespec provenance govern --files pkg/proxy/postgresql/proxy.go --json</code></pre>
+                    </div>
+                    <p><strong>Options:</strong></p>
+                    <ul>
+                        <li><code>--files f1 f2 f3</code> - Files to look up governance for (positional args also accepted)</li>
+                        <li><code>--json</code> - Machine-readable output (<code>{files, governing:[{id,status}], next}</code>)</li>
+                        <li><code>-c, --config path</code> - Use custom config</li>
+                    </ul>
+
                     <h3>Search (Semantic)</h3>
                     <p>Search provenance records by semantic similarity:</p>
                     <div class="code-block">
@@ -1137,6 +1187,25 @@ linespec provenance sync --force  # ignore the TTL and re-fetch all repos</code>
                         <pre><code>linespec provenance install-skills</code></pre>
                     </div>
                     <p>Installs both the <code>provenance</code> and <code>linespec-testing</code> skills to <code>.claude/skills/</code> by default. Use <code>--path</code> to override the target directory. Existing skill directories are overwritten silently. Once installed, invoke with <code>/provenance</code> or <code>/linespec-testing</code> in Claude Code.</p>
+
+                    <h3>Install Plugin (Claude Code)</h3>
+                    <p>Install the Claude Code <strong>provenance plugin</strong>, which surfaces the advice engine inside the agent loop:</p>
+                    <div class="code-block">
+                        <div class="code-header">
+                            <span>Terminal</span>
+                            <button class="copy-btn" aria-label="Copy code">
+                                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                                    <path d="M4 4v8h8V4H4zM2 2h12v12H2V2z" stroke="currentColor" stroke-width="1.5"/>
+                                </svg>
+                            </button>
+                        </div>
+                        <pre><code>linespec provenance install-plugin                     # install to .claude/plugins/ (default)
+linespec provenance install-plugin --path path/to/plugins</code></pre>
+                    </div>
+                    <p>The plugin ships three hooks, all rendering from <code>linespec provenance</code> (no duplicated logic): <strong>SessionStart</strong> injects the ambient <code>next</code> action; <strong>PreToolUse (Edit/Write)</strong> advisorily notes the open record to tag on the first edit of a governed file (never blocks); <strong>PostToolUse (Bash)</strong> surfaces the engine's remediation when a <code>git commit</code> is rejected on a provenance violation. It also bundles a <code>/provenance-next</code> slash command. Installable via this command (the plugin is embedded in the binary) or the Claude Code marketplace via the bundled <code>.claude-plugin/marketplace.json</code> (<code>claude plugin install</code>).</p>
+
+                    <h3>Scope Cache</h3>
+                    <p><code>context</code>, <code>next</code>, and <code>govern</code> are backed by a scope cache at <code>.linespec/scope-index.json</code> — a compact projection of each record's governance fields plus a cheap stat-based fingerprint of the provenance directory. On a fingerprint match the per-file lookups skip the full record load; on any mismatch or read error they fall back to the authoritative load. The cache is machine-specific (gitignored), self-healing, and safe to delete at any time — it simply rebuilds.</p>
                 </section>
 
                 <section id="config" class="docs-section">
@@ -1166,6 +1235,10 @@ linespec provenance sync --force  # ignore the TTL and re-fetch all repos</code>
 
   # Run associated_specs before allowing a completion-transition commit (default: false)
   run_associated_specs_on_complete: false
+
+  # Severity of the completion-time cross-record overlap teeth: block|warn|off
+  # (default: block). complete --force does NOT bypass these.
+  overlap_specs_on_complete: block
 
   # Additional directories to load records from (for monorepos)
   shared_repos:

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -347,6 +347,7 @@ type ProvenanceConfig struct {
 	CommitTagRequired            bool               `yaml:"commit_tag_required"`              // whether commits must reference a prov ID
 	AutoAffectedScope            bool               `yaml:"auto_affected_scope"`              // whether to auto-populate affected_scope from git diffs
 	RunAssociatedSpecsOnComplete bool               `yaml:"run_associated_specs_on_complete"` // whether to run associated_specs before committing a completion transition
+	OverlapSpecsOnComplete       string             `yaml:"overlap_specs_on_complete"`        // severity of the cross-record overlap teeth at completion: block (default) | warn | off
 	CommitOnStatusChange         bool               `yaml:"commit_on_status_change"`          // whether to auto-commit after open, complete, or deprecate transitions
 	Embedding                    *EmbeddingConfig   `yaml:"embedding,omitempty"`              // embedding API configuration
 	ManifestURL                  string             `yaml:"manifest_url,omitempty"`           // source manifest URL set by linespec clone

--- a/pkg/provenance/commands.go
+++ b/pkg/provenance/commands.go
@@ -3,6 +3,7 @@ package provenance
 import (
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/livecodelife/linespec/pkg/config"
 	"github.com/livecodelife/linespec/pkg/embeddings"
+	plugin "github.com/livecodelife/linespec/plugins/provenance"
 )
 
 // Commands provides all provenance CLI commands
@@ -1529,6 +1531,65 @@ exit $exit_code
 	fmt.Fprintln(os.Stdout, "    · Runs per-pack config for relevant staged changes (multi-pack aware)")
 	fmt.Fprintln(os.Stdout)
 
+	return nil
+}
+
+// InstallPluginOptions holds options for the install-plugin command.
+type InstallPluginOptions struct {
+	Path string // target plugins directory relative to repo root (default: .claude/plugins)
+}
+
+// InstallPlugin extracts the embedded Claude Code provenance plugin into the target
+// config directory (default <repo>/.claude/plugins/linespec-provenance), preserving
+// directory structure and re-applying the executable bit to *.sh hook scripts (which
+// embed.FS drops). It writes ONLY the plugin's own files — it never edits or clobbers
+// unrelated user Claude Code config.
+func (c *Commands) InstallPlugin(opts InstallPluginOptions) error {
+	base := opts.Path
+	if base == "" {
+		base = ".claude/plugins"
+	}
+	// A relative --path is resolved against the repo root; an absolute --path is used
+	// as-is (so callers can install into an arbitrary config dir).
+	dest := filepath.Join(base, "linespec-provenance")
+	if !filepath.IsAbs(base) {
+		dest = filepath.Join(c.RepoRoot, base, "linespec-provenance")
+	}
+
+	err := fs.WalkDir(plugin.Files, ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == "." {
+			return nil
+		}
+		target := filepath.Join(dest, path)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		data, err := plugin.Files.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return err
+		}
+		mode := os.FileMode(0644)
+		if strings.HasSuffix(path, ".sh") {
+			mode = 0755
+		}
+		return os.WriteFile(target, data, mode)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to install plugin: %w", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "✓ Installed plugin 'linespec-provenance' to %s\n", dest)
+	fmt.Fprintf(os.Stdout, "\nIt adds three hooks (session-start guidance, per-edit governance, commit remediation),\n")
+	fmt.Fprintf(os.Stdout, "all rendered from `linespec provenance`. Enable it in your Claude Code settings,\n")
+	fmt.Fprintf(os.Stdout, "or install via the marketplace instead:\n")
+	fmt.Fprintf(os.Stdout, "  claude plugin marketplace add <repo>/plugins/provenance\n")
+	fmt.Fprintf(os.Stdout, "  claude plugin install linespec-provenance@linespec\n\n")
 	return nil
 }
 

--- a/pkg/provenance/commands.go
+++ b/pkg/provenance/commands.go
@@ -94,6 +94,10 @@ func NewCommandsWithEmbedder(config *ProvenanceConfig, repoRoot string, output *
 		return nil, fmt.Errorf("failed to load provenance records: %w", err)
 	}
 
+	// Keep the scope cache warm for the `next` fast path (prov-2026-007c8893).
+	// Best-effort and only rewrites when stale, so the already-fresh case is cheap.
+	refreshScopeIndexCache(repoRoot, loaderDirs(config.Dir, sharedDirs), loader.Records)
+
 	// Create linter with hash-based integrity checker
 	linter := NewLinter(loader, config.Enforcement)
 	linter.Hasher = NewHasher(repoRoot)

--- a/pkg/provenance/commands.go
+++ b/pkg/provenance/commands.go
@@ -2038,6 +2038,43 @@ type ContextOptions struct {
 }
 
 // Context retrieves provenance context for the given files
+// NextOptions configures the `next` command.
+type NextOptions struct {
+	Files      []string // intended files (--files / --plan / positional args)
+	Format     string   // human (default) | json
+	ConfigFile string   // path to custom .linespec.yml file
+}
+
+// Next computes and renders the correct next provenance action for the current
+// state. It is the I/O boundary for the advice engine: it gathers records,
+// staged files, and working-tree changes, then hands a fully-populated NextState
+// to the pure Advise function. Both the `next` command and the routed error
+// hints (Phase 2c) render from that one engine.
+func (c *Commands) Next(opts NextOptions) error {
+	state := NextState{
+		Records:           c.Loader.Records,
+		IntendedFiles:     opts.Files,
+		CommitTagRequired: c.Config != nil && c.Config.CommitTagRequired,
+	}
+
+	if c.Git != nil {
+		if staged, err := c.Git.GetStagedFiles(); err == nil {
+			state.StagedFiles = staged
+		}
+		if changed, err := c.Git.GetWorkingTreeChanges(); err == nil {
+			state.ChangedFiles = changed
+		}
+	}
+
+	actions := Advise(state)
+
+	if opts.Format == "json" {
+		return c.Formatter.FormatNextJSON(actions)
+	}
+	c.Formatter.FormatNext(actions)
+	return nil
+}
+
 func (c *Commands) Context(opts ContextOptions) error {
 	if len(opts.Files) == 0 {
 		c.Formatter.FormatError("No files specified. Provide file paths as arguments or use --files flag.")

--- a/pkg/provenance/commands.go
+++ b/pkg/provenance/commands.go
@@ -1,6 +1,7 @@
 package provenance
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -2120,6 +2121,76 @@ func (c *Commands) Next(opts NextOptions) error {
 		return c.Formatter.FormatNextJSON(actions)
 	}
 	c.Formatter.FormatNext(actions)
+	return nil
+}
+
+// GovernOptions configures the `govern` command — the active-only per-file
+// governance lookup the 5c plugin hook consumes.
+type GovernOptions struct {
+	Files      []string // files to look up governance for
+	Format     string   // human (default) | json
+	ConfigFile string   // path to custom .linespec.yml file
+}
+
+// governingJSON is the stable hook-facing shape of one active governing record.
+type governingJSON struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+// Govern reports the ACTIVE records (open + implemented) that govern the given
+// files, plus the engine's primary next action so a caller can end with a `next`
+// suggestion. Superseded/deprecated records are excluded — see
+// activeGoverningRecords. This is the hook-facing lookup; the full `context`
+// command still shows history.
+func (c *Commands) Govern(opts GovernOptions) error {
+	active := activeGoverningRecords(c.Loader.Records, opts.Files)
+
+	state := NextState{
+		Records:           c.Loader.Records,
+		IntendedFiles:     opts.Files,
+		CommitTagRequired: c.Config != nil && c.Config.CommitTagRequired,
+	}
+	if c.Git != nil {
+		if staged, err := c.Git.GetStagedFiles(); err == nil {
+			state.StagedFiles = staged
+		}
+		if changed, err := c.Git.GetWorkingTreeChanges(); err == nil {
+			state.ChangedFiles = changed
+		}
+	}
+	actions := Advise(state)
+	var primary *NextAction
+	if len(actions) > 0 {
+		primary = &actions[0]
+	}
+
+	if opts.Format == "json" {
+		governing := make([]governingJSON, 0, len(active))
+		for _, r := range active {
+			governing = append(governing, governingJSON{ID: r.ID, Status: string(r.Status)})
+		}
+		out := struct {
+			Files     []string        `json:"files"`
+			Governing []governingJSON `json:"governing"`
+			Next      *NextAction     `json:"next,omitempty"`
+		}{Files: opts.Files, Governing: governing, Next: primary}
+		enc := json.NewEncoder(c.Formatter.Output)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+
+	if len(active) == 0 {
+		fmt.Fprintf(c.Formatter.Output, "No active records govern %s.\n", strings.Join(opts.Files, ", "))
+	} else {
+		fmt.Fprintf(c.Formatter.Output, "Active records governing %s:\n", strings.Join(opts.Files, ", "))
+		for _, r := range active {
+			fmt.Fprintf(c.Formatter.Output, "  · %s [%s]\n", r.ID, r.Status)
+		}
+	}
+	if primary != nil && primary.Command != "" {
+		fmt.Fprintf(c.Formatter.Output, "Next: %s\n  %s\n", primary.Reason, primary.Command)
+	}
 	return nil
 }
 

--- a/pkg/provenance/commands.go
+++ b/pkg/provenance/commands.go
@@ -33,9 +33,36 @@ type ProvenanceConfig struct {
 	CommitTagRequired            bool
 	AutoAffectedScope            bool
 	RunAssociatedSpecsOnComplete bool
+	OverlapSpecsOnComplete       string // block (default) | warn | off — severity of the cross-record overlap teeth at completion
 	CommitOnStatusChange         bool
 	Embedding                    *config.EmbeddingConfig
 	ManifestURL                  string // source manifest URL, set by linespec clone
+}
+
+// Overlap-teeth severity modes for overlap_specs_on_complete. block is the default
+// and matches the original Phase 3/4 behavior (prov-2026-bc57fbdc).
+const (
+	OverlapSpecsBlock = "block" // run touched sealed records' specs; roll back on failure
+	OverlapSpecsWarn  = "warn"  // run them; a failure becomes a non-blocking FYI, completion proceeds
+	OverlapSpecsOff   = "off"   // skip the cross-record teeth entirely (own specs still run)
+)
+
+// normalizeOverlapMode maps a configured overlap_specs_on_complete value to a known
+// mode. Empty defaults to block (backward compatible). Any unrecognized value also
+// falls back to block — never silently off — with a one-line stderr notice so a typo
+// cannot quietly disable the teeth.
+func normalizeOverlapMode(mode string) string {
+	switch mode {
+	case "":
+		return OverlapSpecsBlock
+	case OverlapSpecsBlock, OverlapSpecsWarn, OverlapSpecsOff:
+		return mode
+	default:
+		fmt.Fprintf(os.Stderr,
+			"Warning: unknown overlap_specs_on_complete %q — defaulting to %q. Valid values: %s, %s, %s.\n",
+			mode, OverlapSpecsBlock, OverlapSpecsBlock, OverlapSpecsWarn, OverlapSpecsOff)
+		return OverlapSpecsBlock
+	}
 }
 
 // NewCommands creates a new commands instance
@@ -861,50 +888,63 @@ func (c *Commands) Complete(opts CompleteOptions) error {
 	// Governance-overlap verification (completion-time teeth). Find the sealed
 	// records this change actually touched — computed from the files across this
 	// record's commits, not glob intersection — and run their associated specs to
-	// confirm their proven behavior still holds. Block completion only on a real
-	// spec failure; otherwise emit a single neutral, non-blocking FYI for the
-	// touched records we could not auto-verify (no runnable specs, or spec-running
-	// disabled). A blocked completion rolls back atomically.
-	if touched := c.completionOverlapSelector(record); len(touched) > 0 {
-		var unverified []*Record
-		specsFailed := false
-		runTeeth := c.Config.RunAssociatedSpecsOnComplete
-		// seen de-duplicates identical spec commands across the touched records so a
-		// shared proof (e.g. `make test`) runs once, not once per record.
-		seen := map[string]bool{}
-		for _, r := range touched {
-			if !runTeeth || len(r.AssociatedSpecs) == 0 {
-				unverified = append(unverified, r)
-				continue
+	// confirm their proven behavior still holds. The overlap_specs_on_complete mode
+	// controls severity: block rolls back on a real spec failure; warn turns a
+	// failure into a non-blocking FYI and proceeds; off skips the teeth entirely
+	// (selection included, so it costs nothing). Remote records are excluded by the
+	// selector. A blocked completion rolls back atomically.
+	overlapMode := normalizeOverlapMode(c.Config.OverlapSpecsOnComplete)
+	if overlapMode != OverlapSpecsOff {
+		if touched := c.completionOverlapSelector(record); len(touched) > 0 {
+			var unverified []*Record
+			var failedRecords []*Record
+			runTeeth := c.Config.RunAssociatedSpecsOnComplete
+			// seen de-duplicates identical spec commands across the touched records so a
+			// shared proof (e.g. `make test`) runs once, not once per record.
+			seen := map[string]bool{}
+			for _, r := range touched {
+				if !runTeeth || len(r.AssociatedSpecs) == 0 {
+					unverified = append(unverified, r)
+					continue
+				}
+				fmt.Fprintf(c.Formatter.Output, "\nVerifying sealed record %s touched by this change (%s)...\n", r.ID, r.Title)
+				ran, failed := c.runRecordSpecs(r, seen)
+				if failed {
+					failedRecords = append(failedRecords, r)
+				}
+				if !ran {
+					unverified = append(unverified, r)
+				}
 			}
-			fmt.Fprintf(c.Formatter.Output, "\nVerifying sealed record %s touched by this change (%s)...\n", r.ID, r.Title)
-			ran, failed := c.runRecordSpecs(r, seen)
-			if failed {
-				specsFailed = true
-			}
-			if !ran {
-				unverified = append(unverified, r)
-			}
-		}
 
-		if specsFailed {
-			rollback(false)
-			c.Formatter.FormatError(fmt.Sprintf(
-				"Cannot complete %s: it changes files governed by a sealed record whose specs now fail.\n\n"+
-					"  A sealed record's proven behavior appears broken by this change, so completion is blocked.\n"+
-					"  The transition was rolled back — %s is unchanged (still %s).\n"+
-					"  Fix the failing spec(s) above, or supersede the affected record, then run 'linespec provenance complete' again.",
-				opts.RecordID, opts.RecordID, origStatus,
-			))
-			return fmt.Errorf("overlapping sealed record spec failed")
-		}
+			if len(failedRecords) > 0 && overlapMode == OverlapSpecsBlock {
+				rollback(false)
+				c.Formatter.FormatError(fmt.Sprintf(
+					"Cannot complete %s: it changes files governed by a sealed record whose specs now fail.\n\n"+
+						"  A sealed record's proven behavior appears broken by this change, so completion is blocked.\n"+
+						"  The transition was rolled back — %s is unchanged (still %s).\n"+
+						"  Fix the failing spec(s) above, or supersede the affected record, then run 'linespec provenance complete' again.\n"+
+						"  (To downgrade this gate, set overlap_specs_on_complete: warn|off in .linespec.yml.)",
+					opts.RecordID, opts.RecordID, origStatus,
+				))
+				return fmt.Errorf("overlapping sealed record spec failed")
+			}
 
-		if len(unverified) > 0 {
-			fmt.Fprintf(c.Formatter.Output,
-				"\nℹ Governance overlap (non-blocking): this change also touches files governed by sealed record(s):\n\n%s\n"+
-					"  No runnable specs were available to auto-verify them. If your change conflicts with\n"+
-					"  their original intent, create a record that supersedes them.\n\n",
-				formatRecordList(unverified))
+			if len(failedRecords) > 0 { // warn mode — surface but do not block
+				fmt.Fprintf(c.Formatter.Output,
+					"\nℹ Governance overlap (non-blocking, warn mode): specs of sealed record(s) you touched failed:\n\n%s\n"+
+						"  Completion proceeds because overlap_specs_on_complete is 'warn'. If the failure is real,\n"+
+						"  fix it or supersede the affected record; if it is flaky/unrelated, no action is needed.\n\n",
+					formatRecordList(failedRecords))
+			}
+
+			if len(unverified) > 0 {
+				fmt.Fprintf(c.Formatter.Output,
+					"\nℹ Governance overlap (non-blocking): this change also touches files governed by sealed record(s):\n\n%s\n"+
+						"  No runnable specs were available to auto-verify them. If your change conflicts with\n"+
+						"  their original intent, create a record that supersedes them.\n\n",
+					formatRecordList(unverified))
+			}
 		}
 	}
 
@@ -1221,7 +1261,10 @@ func (c *Commands) runRecordSpecs(record *Record, seen map[string]bool) (ran boo
 func (c *Commands) overlappingSealedRecords(self *Record, changedFiles []string) []*Record {
 	var out []*Record
 	for _, r := range c.Loader.Records {
-		if r.ID == self.ID || r.Status != StatusImplemented || r.SealedAtSHA == "" {
+		// Remote (shared_repos cache) records are skipped: their associated_specs
+		// paths are relative to the origin repo and may not resolve here, and they
+		// cannot be superseded locally — so they must not gate local completion.
+		if r.ID == self.ID || r.Status != StatusImplemented || r.SealedAtSHA == "" || c.isRemoteRecord(r) {
 			continue
 		}
 		for _, f := range changedFiles {
@@ -1258,7 +1301,8 @@ func (c *Commands) completionOverlapSelector(self *Record) []*Record {
 func (c *Commands) declaredOverlapSealedRecords(self *Record) []*Record {
 	var out []*Record
 	for _, r := range c.Loader.Records {
-		if r.ID == self.ID || r.Status != StatusImplemented || r.SealedAtSHA == "" {
+		// Skip remote (shared_repos cache) records — see overlappingSealedRecords.
+		if r.ID == self.ID || r.Status != StatusImplemented || r.SealedAtSHA == "" || c.isRemoteRecord(r) {
 			continue
 		}
 		if scopesOverlap(self, r) {

--- a/pkg/provenance/formatter.go
+++ b/pkg/provenance/formatter.go
@@ -636,9 +636,10 @@ func (f *Formatter) FormatCheckResult(violations []Violation, staleWarnings []St
 			fmt.Fprintln(f.Output)
 		}
 
-		fmt.Fprintf(f.Output, "  %s If this change is intentional, create a new Provenance Record\n", f.colored("Hint:", colorCyan))
-		fmt.Fprintf(f.Output, "       that governs this file and tag your commit with it. (Supersede the\n")
-		fmt.Fprintf(f.Output, "       existing record only if you are revising its decision.)\n")
+		// Render the create-not-supersede framing from the single engine-owned
+		// source (next.go) so this hint never drifts from `next` or the skill.
+		fmt.Fprintf(f.Output, "  %s If this change is intentional, %s\n",
+			f.colored("Hint:", colorCyan), HintCreateNotSupersede())
 	}
 
 	if len(staleWarnings) > 0 {

--- a/pkg/provenance/formatter.go
+++ b/pkg/provenance/formatter.go
@@ -1187,3 +1187,56 @@ func (f *Formatter) FormatContextJSON(result *ContextResult) error {
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(jsonResult)
 }
+
+// FormatNext renders advice-engine actions for humans. Element 0 is the single
+// primary recommendation; any remaining actions are shown as follow-ups.
+func (f *Formatter) FormatNext(actions []NextAction) {
+	if len(actions) == 0 {
+		return
+	}
+	primary := actions[0]
+
+	fmt.Fprintf(f.Output, "\n%s %s\n", f.colored("Next:", colorCyan), primary.Reason)
+	if primary.Command != "" {
+		fmt.Fprintf(f.Output, "\n  %s\n", f.colored(primary.Command, colorGreen))
+	}
+	if primary.Detail != "" {
+		fmt.Fprintln(f.Output)
+		for _, line := range strings.Split(primary.Detail, "\n") {
+			fmt.Fprintf(f.Output, "  %s\n", line)
+		}
+	}
+	if len(primary.Governing) > 0 {
+		fmt.Fprintf(f.Output, "\n  %s %s\n",
+			f.colored("Governing (no supersede needed):", colorYellow),
+			strings.Join(primary.Governing, ", "))
+	}
+
+	if len(actions) > 1 {
+		fmt.Fprintf(f.Output, "\n  %s\n", f.colored("Then:", colorCyan))
+		for _, a := range actions[1:] {
+			if a.Command != "" {
+				fmt.Fprintf(f.Output, "    · %s — %s\n", a.Command, a.Reason)
+			} else {
+				fmt.Fprintf(f.Output, "    · %s\n", a.Reason)
+			}
+		}
+	}
+	fmt.Fprintln(f.Output)
+}
+
+// FormatNextJSON emits the advice-engine actions as JSON for hook/agent
+// consumption. The shape is stable: {"primary": <action>, "actions": [<action>...]}.
+func (f *Formatter) FormatNextJSON(actions []NextAction) error {
+	type jsonNext struct {
+		Primary *NextAction  `json:"primary"`
+		Actions []NextAction `json:"actions"`
+	}
+	out := jsonNext{Actions: actions}
+	if len(actions) > 0 {
+		out.Primary = &actions[0]
+	}
+	encoder := json.NewEncoder(f.Output)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(out)
+}

--- a/pkg/provenance/git.go
+++ b/pkg/provenance/git.go
@@ -298,6 +298,33 @@ func (g *Git) GetStagedFiles() ([]string, error) {
 	return result, nil
 }
 
+// GetWorkingTreeChanges returns every file that differs from HEAD — staged and
+// unstaged combined (`git diff --name-only HEAD`). It is the "what am I working
+// on" signal the advice engine uses for ambient `next` when no intended files are
+// given.
+func (g *Git) GetWorkingTreeChanges() ([]string, error) {
+	cmd := exec.Command("git", "diff", "--name-only", "HEAD")
+	if g.RepoRoot != "" {
+		cmd.Dir = g.RepoRoot
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get working tree changes: %w", err)
+	}
+
+	files := strings.Split(string(output), "\n")
+	var result []string
+	for _, f := range files {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			result = append(result, f)
+		}
+	}
+
+	return result, nil
+}
+
 // ReadCommitMessageFile reads the commit message from a file
 func (g *Git) ReadCommitMessageFile(path string) (string, error) {
 	data, err := os.ReadFile(path)

--- a/pkg/provenance/git.go
+++ b/pkg/provenance/git.go
@@ -868,16 +868,10 @@ func (c *CommitChecker) CheckForStaleScopeWarnings(record *Record, changedFiles 
 
 		// Check if this specific file has changed since sealing
 		if !changedSinceSeal[changedFile] {
-			// File hasn't changed since record was sealed - this is a stale scope warning
+			// Wording is sourced from the single engine-owned helper (next.go)
+			// so the commit-time warning never drifts from `next` or the skill.
 			shortSHA := record.SealedAtSHA[:7]
-			warning := fmt.Sprintf(
-				"Note: '%s' is governed by implemented record %s (sealed at %s). "+
-					"This is informational and non-blocking — no action is required. "+
-					"Make your change under your own new record and tag your commit with it. "+
-					"Supersede %s only if you are intentionally revising that record's decision:\n"+
-					"  linespec provenance create --title \"Your change description\" --supersedes %s",
-				changedFile, record.ID, shortSHA, record.ID, record.ID,
-			)
+			warning := HintStaleScope(changedFile, record.ID, shortSHA)
 			warnings = append(warnings, StaleScopeWarning{
 				RecordID: record.ID,
 				File:     changedFile,

--- a/pkg/provenance/next.go
+++ b/pkg/provenance/next.go
@@ -72,6 +72,33 @@ type NextState struct {
 	CommitTagRequired bool
 }
 
+// HintCreateNotSupersede returns the canonical guidance shown whenever a change
+// touches files already governed by existing records: create ONE new record
+// covering your files and tag your commits with it — supersede only when you are
+// deliberately revising the decision a record captured. This is the single source
+// of that wording. The `next` create advice, the commit-violation hint
+// (formatter.go), and any other surface all render from it so the framing that
+// caused the original ~$400 incident can never drift between surfaces again.
+func HintCreateNotSupersede() string {
+	return "create a new record that governs this file and tag your commit with it. " +
+		"Supersede an existing record only when you are deliberately revising the decision it captured."
+}
+
+// HintStaleScope returns the canonical, non-blocking message shown when a change
+// touches a file governed by an already-implemented (sealed) record. It is
+// informational only — no action is required, and it is NOT a reason to supersede
+// anything. The wording lives here so the commit-time warning and any other
+// surface stay single-sourced.
+func HintStaleScope(file, recordID, shortSHA string) string {
+	return fmt.Sprintf(
+		"Note: '%s' is governed by implemented record %s (sealed at %s). "+
+			"This is informational and non-blocking — no action is required. "+
+			"Make your change under your own new record and tag your commit with it. "+
+			"Supersede %s only if you are intentionally revising that record's decision:\n"+
+			"  linespec provenance create --title \"Your change description\" --supersedes %s",
+		file, recordID, shortSHA, recordID, recordID)
+}
+
 // Advise is THE advice engine: a pure function mapping provenance state to the
 // ordered list of correct next actions, with record IDs filled in. It performs
 // no I/O and has no side effects. Element 0 of the result is the single primary
@@ -154,10 +181,8 @@ func createAction(governing []string) NextAction {
 	reason := "No record governs these files — create one blueprint covering them."
 	if len(governing) > 0 {
 		reason = fmt.Sprintf(
-			"%d record(s) already govern these files, but you do NOT need to supersede them — "+
-				"create one new blueprint covering your files and tag your commits with it. "+
-				"Supersede only if you are deliberately revising a captured decision.",
-			len(governing))
+			"%d record(s) already govern these files, but you do NOT need to supersede them — %s",
+			len(governing), HintCreateNotSupersede())
 	}
 	return NextAction{
 		Kind:      ActionCreate,

--- a/pkg/provenance/next.go
+++ b/pkg/provenance/next.go
@@ -277,8 +277,22 @@ func topLevelRecords(records []*Record) []*Record {
 	return out
 }
 
-// topLevelGoverning returns the top-level records (blueprint/bug) whose scope
-// covers at least one of the files, sorted by ID for determinism. Returns nil
+// explicitlyGoverns reports whether a record CLAIMS the given file — i.e. it is in
+// allowlist mode (non-empty affected_scope) and the file matches that scope.
+// Observed-mode records (empty affected_scope) permit any file but do not claim
+// any specific one, so they are NOT treated as governing a particular file. This
+// keeps the engine from selecting a permissive observed record as the active one
+// for every file, and keeps the advisory governing list free of noise.
+func explicitlyGoverns(r *Record, file string) bool {
+	if r.ScopeMode() != "allowlist" {
+		return false
+	}
+	inScope, err := r.IsInScope(file)
+	return err == nil && inScope
+}
+
+// topLevelGoverning returns the top-level records (blueprint/bug) that explicitly
+// govern at least one of the files, sorted by ID for determinism. Returns nil
 // when files is empty.
 func topLevelGoverning(records []*Record, files []string) []*Record {
 	if len(files) == 0 {
@@ -290,7 +304,7 @@ func topLevelGoverning(records []*Record, files []string) []*Record {
 			continue
 		}
 		for _, f := range files {
-			if inScope, err := r.IsInScope(f); err == nil && inScope {
+			if explicitlyGoverns(r, f) {
 				out = append(out, r)
 				break
 			}
@@ -300,14 +314,14 @@ func topLevelGoverning(records []*Record, files []string) []*Record {
 	return out
 }
 
-// governingRecords returns every record (any tier/status) whose scope covers at
-// least one of the files, sorted by ID.
+// governingRecords returns every record (any tier/status) that explicitly governs
+// at least one of the files, sorted by ID.
 func governingRecords(records []*Record, files []string) []string {
 	seen := map[string]bool{}
 	var ids []string
 	for _, r := range records {
 		for _, f := range files {
-			if inScope, err := r.IsInScope(f); err == nil && inScope {
+			if explicitlyGoverns(r, f) {
 				if !seen[r.ID] {
 					seen[r.ID] = true
 					ids = append(ids, r.ID)

--- a/pkg/provenance/next.go
+++ b/pkg/provenance/next.go
@@ -1,0 +1,355 @@
+package provenance
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// next.go hosts the Phase 2 advice engine (prov-2026-54aaf9cf): a single pure
+// function that maps the current provenance state — records, statuses, staged
+// files, branch diff, and optional intended files — to the correct next action,
+// with concrete record IDs filled in. Every guidance surface (the `next`
+// command, CLI error hints, the skill, and the future plugin) renders from this
+// one engine so guidance only has to be correct in one place.
+//
+// Design is recorded in imprint prov-2026-a053a867.
+
+// ActionKind enumerates the kinds of next action the advice engine can recommend.
+type ActionKind string
+
+const (
+	// ActionCreate — no record governs the relevant files; create a blueprint.
+	ActionCreate ActionKind = "create"
+	// ActionOpen — a draft record governs the work; open it to enable enforcement.
+	ActionOpen ActionKind = "open"
+	// ActionAddSpec — an open record has no associated_specs; add a proof artifact.
+	ActionAddSpec ActionKind = "add_spec"
+	// ActionCommit — there are staged changes; commit them tagged with the record.
+	ActionCommit ActionKind = "commit"
+	// ActionImplementImprint — an imprint of the active blueprint is not implemented.
+	ActionImplementImprint ActionKind = "implement_imprint"
+	// ActionComplete — the active record is ready to be completed.
+	ActionComplete ActionKind = "complete"
+	// ActionChooseRecord — more than one open record governs the files; pick one.
+	ActionChooseRecord ActionKind = "choose_record"
+	// ActionNone — nothing pending; the tree is clean and no work is in flight.
+	ActionNone ActionKind = "none"
+)
+
+// NextAction is a single recommended action: a ready-to-run command (with record
+// IDs already substituted) plus a one-line human reason.
+type NextAction struct {
+	Kind     ActionKind `json:"kind"`
+	Command  string     `json:"command,omitempty"`
+	Reason   string     `json:"reason"`
+	RecordID string     `json:"record_id,omitempty"`
+	// Governing lists record IDs that govern the relevant files. It is advisory:
+	// these records do NOT need to be superseded just because they govern the
+	// files (Phase 1 framing).
+	Governing []string `json:"governing,omitempty"`
+	// Detail carries an optional multi-line elaboration (e.g. an associated_specs
+	// YAML shape). Renderers may show or omit it.
+	Detail string `json:"detail,omitempty"`
+}
+
+// NextState is the already-gathered, side-effect-free snapshot the engine reasons
+// over. The caller (the `next` command, an error-hint site, or a hook) gathers
+// this; Advise itself performs no I/O. This is what makes the decision logic
+// unit-testable and reusable from every surface.
+type NextState struct {
+	// Records is every loaded record (local + shared cache).
+	Records []*Record
+	// StagedFiles is `git diff --cached --name-only`.
+	StagedFiles []string
+	// ChangedFiles is the broader working/branch diff (unstaged + committed-on-branch).
+	ChangedFiles []string
+	// IntendedFiles is the set of files the agent plans to change (from
+	// `next --files`/`--plan`). When non-empty it takes precedence over the git
+	// diffs so governance surfaces during planning, before any edit.
+	IntendedFiles []string
+	// CommitTagRequired mirrors config.commit_tag_required; affects commit wording.
+	CommitTagRequired bool
+}
+
+// Advise is THE advice engine: a pure function mapping provenance state to the
+// ordered list of correct next actions, with record IDs filled in. It performs
+// no I/O and has no side effects. Element 0 of the result is the single primary
+// recommendation; later elements are optional follow-ups. The slice is never
+// empty — a clean, idle state returns a single ActionNone.
+func Advise(state NextState) []NextAction {
+	files := relevantFiles(state)
+
+	open := recordsByStatus(state.Records, StatusOpen)
+	openGoverning := topLevelGoverning(open, files)
+
+	// Resolve the active open record (the one the agent is working under).
+	var active *Record
+	switch {
+	case len(openGoverning) == 1:
+		active = openGoverning[0]
+	case len(openGoverning) > 1:
+		return []NextAction{chooseRecordAction(openGoverning, files)}
+	case len(files) == 0:
+		// Ambient, clean tree: a lone open blueprint/bug is the active work.
+		bps := topLevelRecords(open)
+		switch len(bps) {
+		case 1:
+			active = bps[0]
+		default:
+			if len(bps) > 1 {
+				return []NextAction{chooseRecordAction(bps, nil)}
+			}
+		}
+	}
+
+	if active != nil {
+		return adviseOnActive(state, active)
+	}
+
+	// No active open record. Is there a draft to open?
+	drafts := recordsByStatus(state.Records, StatusDraft)
+	draftGoverning := topLevelGoverning(drafts, files)
+	var draft *Record
+	switch {
+	case len(draftGoverning) >= 1:
+		draft = draftGoverning[0]
+	case len(files) == 0 && len(topLevelRecords(drafts)) == 1:
+		draft = topLevelRecords(drafts)[0]
+	}
+	if draft != nil {
+		return []NextAction{openAction(draft)}
+	}
+
+	// Nothing governs the files and there is no draft.
+	if len(files) == 0 {
+		return []NextAction{{
+			Kind:   ActionNone,
+			Reason: "No work in flight and no staged changes. Start a blueprint when you begin a change.",
+			Command: `linespec provenance create --title "..." --type blueprint --no-edit`,
+		}}
+	}
+	return []NextAction{createAction(governingRecords(state.Records, files))}
+}
+
+// adviseOnActive returns the next action for an open record the agent is working
+// under. Precedence: add missing spec -> commit staged work -> close pending
+// imprints -> complete.
+func adviseOnActive(state NextState, active *Record) []NextAction {
+	if len(active.AssociatedSpecs) == 0 {
+		return []NextAction{addSpecAction(active)}
+	}
+	if len(state.StagedFiles) > 0 {
+		return []NextAction{commitAction(active, state.CommitTagRequired)}
+	}
+	if pending := unimplementedImprints(state.Records, active.ID); len(pending) > 0 {
+		return []NextAction{implementImprintAction(pending[0], active)}
+	}
+	return []NextAction{completeAction(active)}
+}
+
+// --- action constructors -------------------------------------------------
+
+func createAction(governing []string) NextAction {
+	reason := "No record governs these files — create one blueprint covering them."
+	if len(governing) > 0 {
+		reason = fmt.Sprintf(
+			"%d record(s) already govern these files, but you do NOT need to supersede them — "+
+				"create one new blueprint covering your files and tag your commits with it. "+
+				"Supersede only if you are deliberately revising a captured decision.",
+			len(governing))
+	}
+	return NextAction{
+		Kind:      ActionCreate,
+		Command:   `linespec provenance create --title "..." --type blueprint --no-edit`,
+		Reason:    reason,
+		Governing: governing,
+	}
+}
+
+func openAction(r *Record) NextAction {
+	return NextAction{
+		Kind:     ActionOpen,
+		Command:  "linespec provenance open --record " + r.ID,
+		Reason:   "Draft " + r.ID + " covers this work — open it to enable scope/spec enforcement.",
+		RecordID: r.ID,
+	}
+}
+
+func addSpecAction(r *Record) NextAction {
+	detail := strings.Join([]string{
+		"# 1. create the proof file first (it must exist before you reference it)",
+		"# 2. add it to the record's associated_specs:",
+		"associated_specs:",
+		"  - path: path/to/proof_test.go",
+		"    type: go_test",
+		"    run_command: make test # {{path}}",
+	}, "\n")
+	return NextAction{
+		Kind:     ActionAddSpec,
+		Reason:   "Open record " + r.ID + " has no associated_specs — add a proof artifact before completing.",
+		RecordID: r.ID,
+		Detail:   detail,
+	}
+}
+
+func commitAction(r *Record, tagRequired bool) NextAction {
+	cmd := fmt.Sprintf(`git commit -m "<description> [%s]"`, r.ID)
+	reason := "You have staged changes — commit them tagged with " + r.ID + "."
+	if !tagRequired {
+		reason += " (commit tag is optional in this repo, but recommended.)"
+	}
+	return NextAction{
+		Kind:     ActionCommit,
+		Command:  cmd,
+		Reason:   reason,
+		RecordID: r.ID,
+	}
+}
+
+func implementImprintAction(imprint, blueprint *Record) NextAction {
+	return NextAction{
+		Kind:     ActionImplementImprint,
+		Command:  "linespec provenance complete --record " + imprint.ID,
+		Reason:   "Imprint " + imprint.ID + " of blueprint " + blueprint.ID + " is not implemented yet — finish and complete it before completing the blueprint.",
+		RecordID: imprint.ID,
+	}
+}
+
+func completeAction(r *Record) NextAction {
+	return NextAction{
+		Kind:     ActionComplete,
+		Command:  "linespec provenance complete --record " + r.ID,
+		Reason:   "Specs are present and no imprints are pending — show proof, then complete " + r.ID + ".",
+		RecordID: r.ID,
+	}
+}
+
+func chooseRecordAction(records []*Record, files []string) NextAction {
+	ids := recordIDs(records)
+	scope := "the files in play"
+	if len(files) > 0 {
+		scope = strings.Join(files, ", ")
+	}
+	return NextAction{
+		Kind: ActionChooseRecord,
+		Reason: fmt.Sprintf(
+			"Multiple open records govern %s: %s. Work under ONE of them and tag your commits with it — do NOT supersede the others.",
+			scope, strings.Join(ids, ", ")),
+		Governing: ids,
+	}
+}
+
+// --- pure helpers --------------------------------------------------------
+
+// relevantFiles returns IntendedFiles when set, otherwise the de-duplicated union
+// of staged and changed files.
+func relevantFiles(state NextState) []string {
+	if len(state.IntendedFiles) > 0 {
+		return dedupe(state.IntendedFiles)
+	}
+	return dedupe(append(append([]string{}, state.StagedFiles...), state.ChangedFiles...))
+}
+
+// isTopLevel reports whether a record is a workable top-level record (blueprint or
+// bug). Empty Type defaults to blueprint for backward compatibility.
+func isTopLevel(r *Record) bool {
+	return r.Type == RecordTypeBlueprint || r.Type == RecordTypeBug || r.Type == ""
+}
+
+func recordsByStatus(records []*Record, status Status) []*Record {
+	var out []*Record
+	for _, r := range records {
+		if r.Status == status {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func topLevelRecords(records []*Record) []*Record {
+	var out []*Record
+	for _, r := range records {
+		if isTopLevel(r) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// topLevelGoverning returns the top-level records (blueprint/bug) whose scope
+// covers at least one of the files, sorted by ID for determinism. Returns nil
+// when files is empty.
+func topLevelGoverning(records []*Record, files []string) []*Record {
+	if len(files) == 0 {
+		return nil
+	}
+	var out []*Record
+	for _, r := range records {
+		if !isTopLevel(r) {
+			continue
+		}
+		for _, f := range files {
+			if inScope, err := r.IsInScope(f); err == nil && inScope {
+				out = append(out, r)
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// governingRecords returns every record (any tier/status) whose scope covers at
+// least one of the files, sorted by ID.
+func governingRecords(records []*Record, files []string) []string {
+	seen := map[string]bool{}
+	var ids []string
+	for _, r := range records {
+		for _, f := range files {
+			if inScope, err := r.IsInScope(f); err == nil && inScope {
+				if !seen[r.ID] {
+					seen[r.ID] = true
+					ids = append(ids, r.ID)
+				}
+				break
+			}
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// unimplementedImprints returns the imprints that implement blueprintID and are
+// not yet implemented, sorted by ID.
+func unimplementedImprints(records []*Record, blueprintID string) []*Record {
+	var out []*Record
+	for _, r := range records {
+		if r.Type == RecordTypeImprint && r.Implements == blueprintID && r.Status != StatusImplemented {
+			out = append(out, r)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+func recordIDs(records []*Record) []string {
+	ids := make([]string, 0, len(records))
+	for _, r := range records {
+		ids = append(ids, r.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func dedupe(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/pkg/provenance/next_test.go
+++ b/pkg/provenance/next_test.go
@@ -159,6 +159,28 @@ func TestAdvise_AmbientSingleOpenBlueprint_AdvancesIt(t *testing.T) {
 	}
 }
 
+func TestHintCreateNotSupersede_FramesSupersedeAsRevisionOnly(t *testing.T) {
+	h := HintCreateNotSupersede()
+	if !containsAny(h, "create a new record") {
+		t.Fatalf("hint must lead with creating a new record: %q", h)
+	}
+	if containsAny(h, "--supersedes") {
+		t.Fatalf("hint must not present the --supersedes command as the default remedy: %q", h)
+	}
+	if !containsAny(h, "deliberately revising") {
+		t.Fatalf("hint must frame supersede as the deliberate-revision branch: %q", h)
+	}
+}
+
+func TestHintStaleScope_NonBlockingAndSpecific(t *testing.T) {
+	h := HintStaleScope("pkg/core/auth.go", "prov-2026-0000beef", "abc1234")
+	for _, want := range []string{"non-blocking", "no action is required", "pkg/core/auth.go", "prov-2026-0000beef"} {
+		if !containsAny(h, want) {
+			t.Fatalf("stale-scope hint missing %q: %s", want, h)
+		}
+	}
+}
+
 func TestAdvise_NeverEmpty(t *testing.T) {
 	if len(Advise(NextState{})) == 0 {
 		t.Fatal("Advise must never return an empty slice")

--- a/pkg/provenance/next_test.go
+++ b/pkg/provenance/next_test.go
@@ -126,6 +126,22 @@ func TestAdvise_MultipleOpenGoverning_ChooseNotSupersede(t *testing.T) {
 	}
 }
 
+func TestAdvise_ObservedModeOpenRecord_NotTreatedAsGoverning(t *testing.T) {
+	// An open record with empty affected_scope (observed mode) permits any file but
+	// claims none. It must NOT be selected as the active record for an arbitrary
+	// file, nor listed as governing it — otherwise every observed record would
+	// hijack advice for every file.
+	observed := bp("prov-2026-0b5e2bed", StatusOpen, nil, spec("x_test.go")) // empty scope
+	s := NextState{Records: []*Record{observed}, IntendedFiles: []string{"pkg/core/auth.go"}}
+	got := primary(t, s)
+	if got.Kind != ActionCreate {
+		t.Fatalf("observed-mode open record must not become active; want ActionCreate, got %s", got.Kind)
+	}
+	if len(got.Governing) != 0 {
+		t.Fatalf("observed-mode record must not appear as governing, got %v", got.Governing)
+	}
+}
+
 func TestAdvise_CleanAmbient_None(t *testing.T) {
 	s := NextState{Records: []*Record{bp("prov-2026-00000001", StatusImplemented, []string{"pkg/core/**"})}}
 	got := primary(t, s)

--- a/pkg/provenance/next_test.go
+++ b/pkg/provenance/next_test.go
@@ -1,0 +1,174 @@
+package provenance
+
+import "testing"
+
+// next_test.go is the proof artifact for the Phase 2 advice engine
+// (prov-2026-54aaf9cf). It asserts the correct primary action for each state
+// branch the engine is responsible for.
+
+func bp(id string, status Status, scope []string, specs ...AssociatedSpec) *Record {
+	return &Record{ID: id, Type: RecordTypeBlueprint, Status: status, AffectedScope: scope, AssociatedSpecs: specs}
+}
+
+func imprint(id, implements string, status Status) *Record {
+	return &Record{ID: id, Type: RecordTypeImprint, Status: status, Implements: implements}
+}
+
+func spec(path string) AssociatedSpec { return AssociatedSpec{Path: path, Type: "go_test"} }
+
+// primary returns the engine's single primary recommendation for a state.
+func primary(t *testing.T, s NextState) NextAction {
+	t.Helper()
+	actions := Advise(s)
+	if len(actions) == 0 {
+		t.Fatal("Advise returned no actions; the slice must never be empty")
+	}
+	return actions[0]
+}
+
+func TestAdvise_NoGoverningRecord_Create(t *testing.T) {
+	s := NextState{
+		Records:       []*Record{bp("prov-2026-00000001", StatusImplemented, []string{"other/**"})},
+		IntendedFiles: []string{"pkg/new/thing.go"},
+	}
+	got := primary(t, s)
+	if got.Kind != ActionCreate {
+		t.Fatalf("want ActionCreate, got %s (%q)", got.Kind, got.Reason)
+	}
+}
+
+func TestAdvise_GovernedBySealed_StillCreate_NoSupersede(t *testing.T) {
+	// A sealed record governs the intended files. Engine must say create, and must
+	// NOT recommend supersede (Phase 1 framing). The sealed record is surfaced as
+	// advisory governing context only.
+	sealed := bp("prov-2026-0000beef", StatusImplemented, []string{"pkg/core/**"})
+	s := NextState{Records: []*Record{sealed}, IntendedFiles: []string{"pkg/core/auth.go"}}
+	got := primary(t, s)
+	if got.Kind != ActionCreate {
+		t.Fatalf("want ActionCreate, got %s", got.Kind)
+	}
+	if len(got.Governing) != 1 || got.Governing[0] != sealed.ID {
+		t.Fatalf("want sealed record surfaced as governing, got %v", got.Governing)
+	}
+	if containsAny(got.Reason, "supersede --", "--supersedes") {
+		t.Fatalf("create advice must not push supersede as the remedy: %q", got.Reason)
+	}
+}
+
+func TestAdvise_DraftGoverning_Open(t *testing.T) {
+	draft := bp("prov-2026-0000d4af", StatusDraft, []string{"pkg/core/**"})
+	s := NextState{Records: []*Record{draft}, IntendedFiles: []string{"pkg/core/auth.go"}}
+	got := primary(t, s)
+	if got.Kind != ActionOpen || got.RecordID != draft.ID {
+		t.Fatalf("want ActionOpen on %s, got %s/%s", draft.ID, got.Kind, got.RecordID)
+	}
+}
+
+func TestAdvise_OpenNoSpecs_AddSpec(t *testing.T) {
+	open := bp("prov-2026-0000a11c", StatusOpen, []string{"pkg/core/**"})
+	s := NextState{Records: []*Record{open}, IntendedFiles: []string{"pkg/core/auth.go"}}
+	got := primary(t, s)
+	if got.Kind != ActionAddSpec || got.RecordID != open.ID {
+		t.Fatalf("want ActionAddSpec on %s, got %s/%s", open.ID, got.Kind, got.RecordID)
+	}
+}
+
+func TestAdvise_OpenWithSpecsAndStaged_Commit(t *testing.T) {
+	open := bp("prov-2026-0000c0de", StatusOpen, []string{"pkg/core/**"}, spec("pkg/core/auth_test.go"))
+	s := NextState{
+		Records:           []*Record{open},
+		IntendedFiles:     []string{"pkg/core/auth.go"},
+		StagedFiles:       []string{"pkg/core/auth.go"},
+		CommitTagRequired: true,
+	}
+	got := primary(t, s)
+	if got.Kind != ActionCommit || got.RecordID != open.ID {
+		t.Fatalf("want ActionCommit on %s, got %s/%s", open.ID, got.Kind, got.RecordID)
+	}
+	if !containsAny(got.Command, open.ID) {
+		t.Fatalf("commit command must embed the record tag: %q", got.Command)
+	}
+}
+
+func TestAdvise_OpenWithUnimplementedImprint_ImplementImprint(t *testing.T) {
+	open := bp("prov-2026-0000b1ue", StatusOpen, []string{"pkg/core/**"}, spec("pkg/core/auth_test.go"))
+	imp := imprint("prov-2026-0000119r", open.ID, StatusOpen)
+	s := NextState{Records: []*Record{open, imp}, IntendedFiles: []string{"pkg/core/auth.go"}}
+	got := primary(t, s)
+	if got.Kind != ActionImplementImprint || got.RecordID != imp.ID {
+		t.Fatalf("want ActionImplementImprint on %s, got %s/%s", imp.ID, got.Kind, got.RecordID)
+	}
+}
+
+func TestAdvise_OpenReadyAllImprintsImplemented_Complete(t *testing.T) {
+	open := bp("prov-2026-0000d011", StatusOpen, []string{"pkg/core/**"}, spec("pkg/core/auth_test.go"))
+	imp := imprint("prov-2026-0000face", open.ID, StatusImplemented)
+	s := NextState{Records: []*Record{open, imp}, IntendedFiles: []string{"pkg/core/auth.go"}}
+	got := primary(t, s)
+	if got.Kind != ActionComplete || got.RecordID != open.ID {
+		t.Fatalf("want ActionComplete on %s, got %s/%s", open.ID, got.Kind, got.RecordID)
+	}
+}
+
+func TestAdvise_MultipleOpenGoverning_ChooseNotSupersede(t *testing.T) {
+	a := bp("prov-2026-0000aaaa", StatusOpen, []string{"pkg/core/**"}, spec("a_test.go"))
+	b := bp("prov-2026-0000bbbb", StatusOpen, []string{"pkg/core/**"}, spec("b_test.go"))
+	s := NextState{Records: []*Record{a, b}, IntendedFiles: []string{"pkg/core/auth.go"}}
+	got := primary(t, s)
+	if got.Kind != ActionChooseRecord {
+		t.Fatalf("want ActionChooseRecord, got %s", got.Kind)
+	}
+	if len(got.Governing) != 2 {
+		t.Fatalf("want both open records listed, got %v", got.Governing)
+	}
+	if containsAny(got.Reason, "--supersedes") {
+		t.Fatalf("choose advice must not recommend the supersede command: %q", got.Reason)
+	}
+}
+
+func TestAdvise_CleanAmbient_None(t *testing.T) {
+	s := NextState{Records: []*Record{bp("prov-2026-00000001", StatusImplemented, []string{"pkg/core/**"})}}
+	got := primary(t, s)
+	if got.Kind != ActionNone {
+		t.Fatalf("want ActionNone on clean ambient state, got %s", got.Kind)
+	}
+}
+
+func TestAdvise_AmbientSingleOpenBlueprint_AdvancesIt(t *testing.T) {
+	open := bp("prov-2026-0000aaff", StatusOpen, []string{"pkg/core/**"}, spec("pkg/core/auth_test.go"))
+	s := NextState{Records: []*Record{open}} // no intended/staged files
+	got := primary(t, s)
+	if got.Kind != ActionComplete || got.RecordID != open.ID {
+		t.Fatalf("ambient with one open ready blueprint should advise complete, got %s/%s", got.Kind, got.RecordID)
+	}
+}
+
+func TestAdvise_NeverEmpty(t *testing.T) {
+	if len(Advise(NextState{})) == 0 {
+		t.Fatal("Advise must never return an empty slice")
+	}
+}
+
+func containsAny(haystack string, needles ...string) bool {
+	for _, n := range needles {
+		if n != "" && stringsContains(haystack, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// stringsContains is a tiny local helper to avoid importing strings in the test
+// file just for one call.
+func stringsContains(s, sub string) bool {
+	return len(sub) <= len(s) && indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/provenance/overlap_specs_test.go
+++ b/pkg/provenance/overlap_specs_test.go
@@ -175,6 +175,105 @@ func TestCompletion_NoSpecOverlap_EmitsNeutralNonBlockingFYI(t *testing.T) {
 	}
 }
 
+func TestCompletion_WarnMode_FailingSpecBecomesNonBlockingFYI(t *testing.T) {
+	cmds, repo, buf := newTransitionTestRepo(t, false)
+	cmds.Config.RunAssociatedSpecsOnComplete = true
+	cmds.Config.OverlapSpecsOnComplete = OverlapSpecsWarn
+	headSHA := gitOutput(t, repo, "rev-parse", "HEAD")
+
+	sealedID := "prov-2026-cc000031"
+	writeRecord(t, repo, sealedID,
+		customRecord(sealedID, "implemented", headSHA, []string{"pkg/foo.go"}, []string{"false"}))
+
+	rID := "prov-2026-cc000032"
+	writeRecord(t, repo, rID,
+		customRecord(rID, "open", "", []string{"pkg/foo.go"}, nil))
+	commitFileChange(t, repo, "pkg/foo.go", "package foo\n", rID)
+	reloadRecords(t, cmds)
+
+	if err := cmds.Complete(CompleteOptions{RecordID: rID}); err != nil {
+		t.Fatalf("warn mode must not block completion on a spec failure: %v", err)
+	}
+	if got := loadedRecord(t, cmds, rID).Status; got != StatusImplemented {
+		t.Errorf("status = %q, want implemented (warn does not roll back)", got)
+	}
+	msg := buf.String()
+	if !strings.Contains(msg, "warn mode") || !strings.Contains(msg, sealedID) {
+		t.Errorf("expected a non-blocking warn-mode FYI naming %s, got:\n%s", sealedID, msg)
+	}
+}
+
+func TestCompletion_OffMode_SkipsTeethEntirely(t *testing.T) {
+	cmds, repo, buf := newTransitionTestRepo(t, false)
+	cmds.Config.RunAssociatedSpecsOnComplete = true
+	cmds.Config.OverlapSpecsOnComplete = OverlapSpecsOff
+	headSHA := gitOutput(t, repo, "rev-parse", "HEAD")
+
+	sealedID := "prov-2026-cc000041"
+	// Failing spec — would block under the default block mode.
+	writeRecord(t, repo, sealedID,
+		customRecord(sealedID, "implemented", headSHA, []string{"pkg/foo.go"}, []string{"false"}))
+
+	rID := "prov-2026-cc000042"
+	writeRecord(t, repo, rID,
+		customRecord(rID, "open", "", []string{"pkg/foo.go"}, nil))
+	commitFileChange(t, repo, "pkg/foo.go", "package foo\n", rID)
+	reloadRecords(t, cmds)
+
+	if err := cmds.Complete(CompleteOptions{RecordID: rID}); err != nil {
+		t.Fatalf("off mode must skip the teeth and complete despite a failing overlap spec: %v", err)
+	}
+	if got := loadedRecord(t, cmds, rID).Status; got != StatusImplemented {
+		t.Errorf("status = %q, want implemented", got)
+	}
+	if msg := buf.String(); strings.Contains(msg, "Verifying sealed record") {
+		t.Errorf("off mode must not run any overlap specs, got:\n%s", msg)
+	}
+}
+
+func TestCompletion_RemoteSealedRecord_ExcludedFromTeeth(t *testing.T) {
+	cmds, repo, _ := newTransitionTestRepo(t, false)
+	cmds.Config.RunAssociatedSpecsOnComplete = true // default block mode
+	headSHA := gitOutput(t, repo, "rev-parse", "HEAD")
+
+	sealedID := "prov-2026-cc000051"
+	writeRecord(t, repo, sealedID,
+		customRecord(sealedID, "implemented", headSHA, []string{"pkg/foo.go"}, []string{"false"}))
+
+	rID := "prov-2026-cc000052"
+	writeRecord(t, repo, rID,
+		customRecord(rID, "open", "", []string{"pkg/foo.go"}, nil))
+	commitFileChange(t, repo, "pkg/foo.go", "package foo\n", rID)
+	reloadRecords(t, cmds)
+
+	// Simulate the sealed record being a remote (shared_repos cache) record by
+	// pointing its FilePath outside the local provenance dir. isRemoteRecord then
+	// excludes it from the teeth, so its failing spec must not gate this completion.
+	loadedRecord(t, cmds, sealedID).FilePath = filepath.Join(repo, "remote-cache", sealedID+".yml")
+
+	if err := cmds.Complete(CompleteOptions{RecordID: rID}); err != nil {
+		t.Fatalf("a remote sealed record must not gate local completion: %v", err)
+	}
+	if got := loadedRecord(t, cmds, rID).Status; got != StatusImplemented {
+		t.Errorf("status = %q, want implemented", got)
+	}
+}
+
+func TestNormalizeOverlapMode(t *testing.T) {
+	cases := map[string]string{
+		"":      OverlapSpecsBlock,
+		"block": OverlapSpecsBlock,
+		"warn":  OverlapSpecsWarn,
+		"off":   OverlapSpecsOff,
+		"bogus": OverlapSpecsBlock, // invalid falls back to block, never silently off
+	}
+	for in, want := range cases {
+		if got := normalizeOverlapMode(in); got != want {
+			t.Errorf("normalizeOverlapMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestCompletion_DedupesIdenticalSpecCommands(t *testing.T) {
 	cmds, repo, _ := newTransitionTestRepo(t, false)
 	cmds.Config.RunAssociatedSpecsOnComplete = true

--- a/pkg/provenance/scope_index.go
+++ b/pkg/provenance/scope_index.go
@@ -1,0 +1,247 @@
+package provenance
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// scope_index.go hosts the Phase 5a cached scope index (prov-2026-007c8893): a
+// compact, persisted view of every record's governance fields plus a cheap
+// stat-based fingerprint of the provenance directory. The `next` dispatch fast
+// path serves from this cache on a fingerprint match, avoiding a full
+// Loader.LoadAll(), so the command is fast enough to sit inside a per-edit Claude
+// Code hook. On any fingerprint mismatch, malformed cache, or read error the
+// caller falls back to the authoritative LoadAll path — the cache is an
+// optimization, never a governance source of truth.
+
+// ScopeEntry is the compact cached projection of a record, carrying only the
+// fields the advice engine (Advise) reads. Heavy prose (intent, constraints,
+// title) is intentionally omitted.
+type ScopeEntry struct {
+	ID             string     `json:"id"`
+	Status         Status     `json:"status"`
+	Type           RecordType `json:"type,omitempty"`
+	AffectedScope  []string   `json:"affected_scope,omitempty"`
+	ForbiddenScope []string   `json:"forbidden_scope,omitempty"`
+	Implements     string     `json:"implements,omitempty"`
+	HasSpecs       bool       `json:"has_specs"`
+}
+
+// ScopeIndex is the persisted scope cache: a fingerprint of the provenance-dir
+// state plus the compact per-record entries.
+type ScopeIndex struct {
+	Fingerprint string       `json:"fingerprint"`
+	Entries     []ScopeEntry `json:"entries"`
+}
+
+// scopeIndexPath returns the on-disk location of the scope cache, alongside the
+// existing .linespec cache artifacts (schema-cache.json, hash_manifest.json).
+func scopeIndexPath(repoRoot string) string {
+	return filepath.Join(repoRoot, ".linespec", "scope-index.json")
+}
+
+// scopeEntryFromRecord projects a full record to a compact cache entry.
+func scopeEntryFromRecord(r *Record) ScopeEntry {
+	return ScopeEntry{
+		ID:             r.ID,
+		Status:         r.Status,
+		Type:           r.Type,
+		AffectedScope:  r.AffectedScope,
+		ForbiddenScope: r.ForbiddenScope,
+		Implements:     r.Implements,
+		HasSpecs:       len(r.AssociatedSpecs) > 0,
+	}
+}
+
+// toRecord reconstructs a lightweight *Record from a cache entry, carrying exactly
+// the fields Advise reads. AssociatedSpecs is synthesized to length 1 when HasSpecs
+// because Advise only checks len(AssociatedSpecs), never the contents.
+func (e ScopeEntry) toRecord() *Record {
+	r := &Record{
+		ID:             e.ID,
+		Status:         e.Status,
+		Type:           e.Type,
+		AffectedScope:  e.AffectedScope,
+		ForbiddenScope: e.ForbiddenScope,
+		Implements:     e.Implements,
+	}
+	if e.HasSpecs {
+		r.AssociatedSpecs = []AssociatedSpec{{}}
+	}
+	return r
+}
+
+// computeScopeFingerprint hashes the (path, size, modtime) of every *.yml across
+// the given directories. It stats only — no file contents are read — so it is a
+// cheap freshness check that changes whenever any record file is added, removed,
+// or modified.
+func computeScopeFingerprint(dirs []string) (string, error) {
+	var tuples []string
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			continue
+		}
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || !strings.HasSuffix(d.Name(), ".yml") {
+				return nil
+			}
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			tuples = append(tuples, fmt.Sprintf("%s\x00%d\x00%d", path, info.Size(), info.ModTime().UnixNano()))
+			return nil
+		})
+		if err != nil {
+			return "", err
+		}
+	}
+	sort.Strings(tuples)
+	h := sha256.New()
+	for _, t := range tuples {
+		h.Write([]byte(t))
+		h.Write([]byte{'\n'})
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// buildScopeIndex projects loaded records into a cache stamped with fingerprint.
+func buildScopeIndex(records []*Record, fingerprint string) *ScopeIndex {
+	entries := make([]ScopeEntry, 0, len(records))
+	for _, r := range records {
+		entries = append(entries, scopeEntryFromRecord(r))
+	}
+	return &ScopeIndex{Fingerprint: fingerprint, Entries: entries}
+}
+
+// save persists the scope index to path, creating the parent dir if needed.
+func (idx *ScopeIndex) save(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(idx)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// loadScopeIndex reads a persisted scope index from path.
+func loadScopeIndex(path string) (*ScopeIndex, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var idx ScopeIndex
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return nil, err
+	}
+	return &idx, nil
+}
+
+// loadFreshScopeIndex loads the cached scope index and returns it only if its
+// fingerprint still matches the current provenance-dir state. ok is false on any
+// miss, staleness, or error, so the caller must fall back to LoadAll.
+func loadFreshScopeIndex(repoRoot string, dirs []string) (*ScopeIndex, bool) {
+	idx, err := loadScopeIndex(scopeIndexPath(repoRoot))
+	if err != nil {
+		return nil, false
+	}
+	fp, err := computeScopeFingerprint(dirs)
+	if err != nil || fp == "" || fp != idx.Fingerprint {
+		return nil, false
+	}
+	return idx, true
+}
+
+// refreshScopeIndexCache rewrites the scope cache from the freshly-loaded records,
+// but only when the on-disk cache is missing or stale — so the common already-fresh
+// case costs one stat-walk and no write. Best-effort: the cache is advisory, so all
+// errors are ignored.
+func refreshScopeIndexCache(repoRoot string, dirs []string, records []*Record) {
+	if repoRoot == "" {
+		return
+	}
+	fp, err := computeScopeFingerprint(dirs)
+	if err != nil || fp == "" {
+		return
+	}
+	path := scopeIndexPath(repoRoot)
+	if existing, err := loadScopeIndex(path); err == nil && existing.Fingerprint == fp {
+		return // already fresh
+	}
+	_ = buildScopeIndex(records, fp).save(path)
+}
+
+// loaderDirs returns the directories LoadAll reads: the (absolute) local provenance
+// dir followed by any shared-repo cache dirs.
+func loaderDirs(absDir string, sharedDirs []string) []string {
+	return append([]string{absDir}, sharedDirs...)
+}
+
+// newCommandsFromScopeIndex builds a Commands whose Loader is populated from the
+// cached scope entries WITHOUT a full LoadAll. It carries only the lightweight
+// records the advice engine needs — enough to serve `next`, nothing more.
+func newCommandsFromScopeIndex(config *ProvenanceConfig, repoRoot, absDir string, output *os.File, color bool, idx *ScopeIndex) *Commands {
+	if config.Enforcement == "" {
+		config.Enforcement = "warn"
+	}
+	loader := NewLoader(absDir, nil)
+	for _, e := range idx.Entries {
+		r := e.toRecord()
+		loader.Records = append(loader.Records, r)
+		loader.RecordsByID[r.ID] = r
+	}
+	return &Commands{
+		Loader:    loader,
+		Git:       NewGit(repoRoot),
+		Formatter: NewFormatter(output, color),
+		Config:    config,
+		RepoRoot:  repoRoot,
+	}
+}
+
+// TryNextFromCache serves `linespec provenance next` from the cached scope index
+// without a full LoadAll, when the cache is fresh. It returns true if it handled
+// the command (output already rendered); false if the caller must fall back to the
+// heavy, authoritative path — on a custom -c config, a cache miss/staleness, or any
+// error. This is the per-edit-hook fast path.
+func TryNextFromCache(config *ProvenanceConfig, repoRoot string, output *os.File, color bool, opts NextOptions) bool {
+	// A custom config path changes which records and directories apply; let the
+	// heavy path reason about it rather than duplicate that logic here.
+	if opts.ConfigFile != "" {
+		return false
+	}
+	if config.Dir == "" {
+		config.Dir = "provenance"
+	}
+	absDir := config.Dir
+	if !filepath.IsAbs(absDir) && repoRoot != "" {
+		absDir = filepath.Join(repoRoot, absDir)
+	}
+	sharedDirs := NewCacheManager(config.SharedRepos, config.CacheTTLMinutes).LoadedDirs()
+	dirs := loaderDirs(absDir, sharedDirs)
+
+	idx, ok := loadFreshScopeIndex(repoRoot, dirs)
+	if !ok {
+		return false
+	}
+	cmds := newCommandsFromScopeIndex(config, repoRoot, absDir, output, color, idx)
+	if err := cmds.Next(opts); err != nil {
+		return false
+	}
+	return true
+}

--- a/pkg/provenance/scope_index.go
+++ b/pkg/provenance/scope_index.go
@@ -214,6 +214,56 @@ func newCommandsFromScopeIndex(config *ProvenanceConfig, repoRoot, absDir string
 	}
 }
 
+// activeGoverningRecords returns the records that are open OR implemented AND
+// explicitly govern (allowlist scope match) at least one of the files, sorted by
+// ID. Superseded and deprecated records are excluded: a per-edit hook that injects
+// "who governs this file" must not surface a decision that has already been
+// replaced or withdrawn (stale-signal noise). This is the active-only lookup the
+// 5c PreToolUse hook consumes — distinct from the full `context` command, which
+// intentionally still shows history.
+func activeGoverningRecords(records []*Record, files []string) []*Record {
+	var out []*Record
+	for _, r := range records {
+		if r.Status != StatusOpen && r.Status != StatusImplemented {
+			continue
+		}
+		for _, f := range files {
+			if explicitlyGoverns(r, f) {
+				out = append(out, r)
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// TryGovernFromCache serves `linespec provenance govern` from the cached scope
+// index without a full LoadAll, mirroring TryNextFromCache. Returns true when it
+// handled the command; false to fall back to the heavy, authoritative path.
+func TryGovernFromCache(config *ProvenanceConfig, repoRoot string, output *os.File, color bool, opts GovernOptions) bool {
+	if opts.ConfigFile != "" {
+		return false
+	}
+	if config.Dir == "" {
+		config.Dir = "provenance"
+	}
+	absDir := config.Dir
+	if !filepath.IsAbs(absDir) && repoRoot != "" {
+		absDir = filepath.Join(repoRoot, absDir)
+	}
+	sharedDirs := NewCacheManager(config.SharedRepos, config.CacheTTLMinutes).LoadedDirs()
+	idx, ok := loadFreshScopeIndex(repoRoot, loaderDirs(absDir, sharedDirs))
+	if !ok {
+		return false
+	}
+	cmds := newCommandsFromScopeIndex(config, repoRoot, absDir, output, color, idx)
+	if err := cmds.Govern(opts); err != nil {
+		return false
+	}
+	return true
+}
+
 // TryNextFromCache serves `linespec provenance next` from the cached scope index
 // without a full LoadAll, when the cache is fresh. It returns true if it handled
 // the command (output already rendered); false if the caller must fall back to the

--- a/pkg/provenance/scope_index_test.go
+++ b/pkg/provenance/scope_index_test.go
@@ -1,0 +1,153 @@
+package provenance
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// scope_index_test.go is the proof artifact for the Phase 5a cached scope index
+// (prov-2026-007c8893): cached-vs-uncached `next` equivalence, stat-fingerprint
+// invalidation, and fallback-to-LoadAll on a corrupt/missing cache.
+
+func entry(id string, status Status, typ RecordType, scope []string, implements string, hasSpecs bool) ScopeEntry {
+	return ScopeEntry{ID: id, Status: status, Type: typ, AffectedScope: scope, Implements: implements, HasSpecs: hasSpecs}
+}
+
+func TestScopeEntry_RoundTripDrivesAdviseLikeFullRecord(t *testing.T) {
+	// A lightweight record reconstructed from a cache entry must produce the same
+	// advice as the full record it was projected from.
+	full := bp("prov-2026-0000a11c", StatusOpen, []string{"pkg/core/**"}) // open, no specs
+	cached := scopeEntryFromRecord(full).toRecord()
+
+	files := []string{"pkg/core/auth.go"}
+	gotFull := Advise(NextState{Records: []*Record{full}, IntendedFiles: files})
+	gotCached := Advise(NextState{Records: []*Record{cached}, IntendedFiles: files})
+	if gotFull[0].Kind != gotCached[0].Kind {
+		t.Fatalf("cached record advice %s != full record advice %s", gotCached[0].Kind, gotFull[0].Kind)
+	}
+	if gotCached[0].Kind != ActionAddSpec {
+		t.Fatalf("expected ActionAddSpec for open+no-specs, got %s", gotCached[0].Kind)
+	}
+}
+
+func TestScopeEntry_HasSpecsPreservedAcrossProjection(t *testing.T) {
+	withSpecs := bp("prov-2026-0000c0de", StatusOpen, []string{"pkg/core/**"}, spec("pkg/core/auth_test.go"))
+	e := scopeEntryFromRecord(withSpecs)
+	if !e.HasSpecs {
+		t.Fatal("HasSpecs must be true when the record has associated_specs")
+	}
+	if len(e.toRecord().AssociatedSpecs) == 0 {
+		t.Fatal("reconstructed record must report having specs so Advise advances past add_spec")
+	}
+}
+
+func TestComputeScopeFingerprint_ChangesWhenRecordChanges(t *testing.T) {
+	dir := t.TempDir()
+	writeYML := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeYML("prov-2026-00000001.yml", "id: prov-2026-00000001\n")
+	fp1, err := computeScopeFingerprint([]string{dir})
+	if err != nil || fp1 == "" {
+		t.Fatalf("fingerprint: %v / %q", err, fp1)
+	}
+	// Adding a record changes the fingerprint.
+	writeYML("prov-2026-00000002.yml", "id: prov-2026-00000002\n")
+	fp2, _ := computeScopeFingerprint([]string{dir})
+	if fp1 == fp2 {
+		t.Fatal("fingerprint must change when a record file is added")
+	}
+	// A non-.yml file does not affect it.
+	writeYML("notes.txt", "ignore me")
+	fp3, _ := computeScopeFingerprint([]string{dir})
+	if fp3 != fp2 {
+		t.Fatal("non-.yml files must not affect the fingerprint")
+	}
+}
+
+func TestLoadFreshScopeIndex_StaleAndCorruptFallBack(t *testing.T) {
+	repo := t.TempDir()
+	provDir := filepath.Join(repo, "provenance")
+	if err := os.MkdirAll(provDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(provDir, "prov-2026-00000001.yml"), []byte("id: x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dirs := []string{provDir}
+
+	// No cache yet -> not fresh.
+	if _, ok := loadFreshScopeIndex(repo, dirs); ok {
+		t.Fatal("expected miss when no cache file exists")
+	}
+
+	// Write a fresh cache -> hit.
+	fp, _ := computeScopeFingerprint(dirs)
+	idx := &ScopeIndex{Fingerprint: fp, Entries: []ScopeEntry{entry("prov-2026-00000001", StatusOpen, RecordTypeBlueprint, nil, "", false)}}
+	if err := idx.save(scopeIndexPath(repo)); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loadFreshScopeIndex(repo, dirs); !ok {
+		t.Fatal("expected a fresh cache to be served")
+	}
+
+	// Change a record -> fingerprint mismatch -> not fresh.
+	if err := os.WriteFile(filepath.Join(provDir, "prov-2026-00000002.yml"), []byte("id: y\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loadFreshScopeIndex(repo, dirs); ok {
+		t.Fatal("expected staleness after a record change")
+	}
+
+	// Corrupt cache -> not fresh (fall back), never a panic.
+	if err := os.WriteFile(scopeIndexPath(repo), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loadFreshScopeIndex(repo, dirs); ok {
+		t.Fatal("expected a corrupt cache to be treated as a miss")
+	}
+}
+
+func TestTryNextFromCache_MatchesHeavyPathOutput(t *testing.T) {
+	cmds, repo, _ := newTransitionTestRepo(t, false)
+
+	// Two records governing different files, in different lifecycle states.
+	writeRecord(t, repo, "prov-2026-aa000001",
+		customRecord("prov-2026-aa000001", "open", "", []string{"pkg/foo.go"}, nil))
+	writeRecord(t, repo, "prov-2026-aa000002",
+		customRecord("prov-2026-aa000002", "draft", "", []string{"pkg/bar.go"}, nil))
+	reloadRecords(t, cmds)
+
+	// Heavy path output for `next --files pkg/bar.go --json`.
+	opts := NextOptions{Files: []string{"pkg/bar.go"}, Format: "json"}
+	var heavy bytes.Buffer
+	cmds.Formatter = NewFormatter(&heavy, false)
+	if err := cmds.Next(opts); err != nil {
+		t.Fatalf("heavy next: %v", err)
+	}
+
+	// Build + persist the cache from the loaded records, then serve via the fast path.
+	provDir := filepath.Join(repo, "provenance")
+	fp, _ := computeScopeFingerprint([]string{provDir})
+	if err := buildScopeIndex(cmds.Loader.Records, fp).save(scopeIndexPath(repo)); err != nil {
+		t.Fatal(err)
+	}
+	idx, ok := loadFreshScopeIndex(repo, []string{provDir})
+	if !ok {
+		t.Fatal("cache should be fresh immediately after building it")
+	}
+	light := newCommandsFromScopeIndex(cmds.Config, repo, provDir, nil, false, idx)
+	var fast bytes.Buffer
+	light.Formatter = NewFormatter(&fast, false)
+	if err := light.Next(opts); err != nil {
+		t.Fatalf("fast next: %v", err)
+	}
+
+	if heavy.String() != fast.String() {
+		t.Fatalf("cached next output differs from uncached:\n--- heavy ---\n%s\n--- fast ---\n%s", heavy.String(), fast.String())
+	}
+}

--- a/pkg/provenance/scope_index_test.go
+++ b/pkg/provenance/scope_index_test.go
@@ -112,6 +112,41 @@ func TestLoadFreshScopeIndex_StaleAndCorruptFallBack(t *testing.T) {
 	}
 }
 
+func TestActiveGoverningRecords_ExcludesSupersededAndDeprecated(t *testing.T) {
+	scope := []string{"pkg/core/**"}
+	open := bp("prov-2026-0000aaaa", StatusOpen, scope)
+	impl := bp("prov-2026-0000bbbb", StatusImplemented, scope)
+	superseded := bp("prov-2026-0000cccc", StatusSuperseded, scope)
+	deprecated := bp("prov-2026-0000dddd", StatusDeprecated, scope)
+	draft := bp("prov-2026-0000eeee", StatusDraft, scope)
+
+	got := activeGoverningRecords([]*Record{open, impl, superseded, deprecated, draft}, []string{"pkg/core/auth.go"})
+
+	gotIDs := map[string]bool{}
+	for _, r := range got {
+		gotIDs[r.ID] = true
+	}
+	if !gotIDs[open.ID] || !gotIDs[impl.ID] {
+		t.Fatalf("active lookup must include open + implemented, got %v", gotIDs)
+	}
+	if gotIDs[superseded.ID] || gotIDs[deprecated.ID] {
+		t.Fatalf("active lookup must EXCLUDE superseded/deprecated, got %v", gotIDs)
+	}
+	if gotIDs[draft.ID] {
+		t.Fatalf("active lookup must exclude draft (not yet enforcing), got %v", gotIDs)
+	}
+}
+
+func TestActiveGoverningRecords_ObservedModeNotGoverning(t *testing.T) {
+	// An open observed-mode record (empty scope) permits any file but claims none —
+	// it must not appear as governing a specific file.
+	observed := bp("prov-2026-0000ffff", StatusImplemented, nil)
+	got := activeGoverningRecords([]*Record{observed}, []string{"pkg/core/auth.go"})
+	if len(got) != 0 {
+		t.Fatalf("observed-mode record must not be reported as governing, got %v", got)
+	}
+}
+
 func TestTryNextFromCache_MatchesHeavyPathOutput(t *testing.T) {
 	cmds, repo, _ := newTransitionTestRepo(t, false)
 

--- a/pkg/provenance/scope_index_test.go
+++ b/pkg/provenance/scope_index_test.go
@@ -112,6 +112,40 @@ func TestLoadFreshScopeIndex_StaleAndCorruptFallBack(t *testing.T) {
 	}
 }
 
+func TestInstallPlugin_WritesPluginTreeWithExecutableHooks(t *testing.T) {
+	repo := t.TempDir()
+	cmds := &Commands{RepoRoot: repo}
+	if err := cmds.InstallPlugin(InstallPluginOptions{}); err != nil {
+		t.Fatalf("InstallPlugin: %v", err)
+	}
+	dest := filepath.Join(repo, ".claude", "plugins", "linespec-provenance")
+	for _, p := range []string{
+		".claude-plugin/plugin.json",
+		".claude-plugin/marketplace.json",
+		"hooks/hooks.json",
+		"hooks/session-start.sh",
+		"hooks/pre-edit.sh",
+		"hooks/post-commit.sh",
+		"commands/provenance-next.md",
+	} {
+		if _, err := os.Stat(filepath.Join(dest, p)); err != nil {
+			t.Errorf("missing installed file %s: %v", p, err)
+		}
+	}
+	// The Go embed source must NOT be installed.
+	if _, err := os.Stat(filepath.Join(dest, "embed.go")); err == nil {
+		t.Error("embed.go must not be part of the installed plugin")
+	}
+	// Hook scripts must be executable.
+	info, err := os.Stat(filepath.Join(dest, "hooks", "session-start.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Errorf("hook scripts must be executable, got mode %v", info.Mode())
+	}
+}
+
 func TestActiveGoverningRecords_ExcludesSupersededAndDeprecated(t *testing.T) {
 	scope := []string{"pkg/core/**"}
 	open := bp("prov-2026-0000aaaa", StatusOpen, scope)

--- a/plugins/provenance/.claude-plugin/marketplace.json
+++ b/plugins/provenance/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "linespec",
+  "owner": {
+    "name": "LineSpec"
+  },
+  "plugins": [
+    {
+      "name": "linespec-provenance",
+      "source": "./",
+      "description": "Ambient provenance guidance for Claude Code, rendered from the linespec advice engine."
+    }
+  ]
+}

--- a/plugins/provenance/.claude-plugin/plugin.json
+++ b/plugins/provenance/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "linespec-provenance",
+  "description": "Surfaces LineSpec provenance guidance in the agent loop: an ambient next-action at session start, advisory governing-record context on the first edit of a governed file, and the engine's exact remediation when a commit is rejected. Every hook renders from `linespec provenance` (the advice engine); none duplicates its logic.",
+  "version": "0.1.0",
+  "keywords": ["provenance", "governance", "linespec"],
+  "hooks": "./hooks/hooks.json"
+}

--- a/plugins/provenance/commands/provenance-next.md
+++ b/plugins/provenance/commands/provenance-next.md
@@ -1,0 +1,10 @@
+---
+description: Show the correct next provenance action for the current repo state
+---
+
+Determine and report the correct next provenance action for this repository, rendering from the linespec advice engine.
+
+- If the user passed file paths in `$ARGUMENTS`, run `linespec provenance next --plan $ARGUMENTS` to plan governance for those files (intent-aware, before editing).
+- Otherwise run `linespec provenance next` for the ambient next action based on staged and working-tree changes.
+
+Report the recommended command and the one-line reason verbatim. Do not invent guidance — if the command surfaces governing records, note that touching a governed file does NOT require superseding it; supersede only when deliberately revising a captured decision.

--- a/plugins/provenance/embed.go
+++ b/plugins/provenance/embed.go
@@ -1,0 +1,14 @@
+// Package plugin embeds the LineSpec provenance Claude Code plugin tree so the
+// distributed linespec binary can install it (prov-2026-cd1405fb / prov-2026-a4204f20).
+// The plugin is also installable directly from this directory via the marketplace
+// (.claude-plugin/marketplace.json) or scripts/install-plugin.
+package plugin
+
+import "embed"
+
+// Files is the embedded plugin tree: the manifest/marketplace under .claude-plugin,
+// the hook config and scripts under hooks, and the slash command under commands.
+// The `all:` prefix is required to include the dot-prefixed .claude-plugin directory.
+//
+//go:embed all:.claude-plugin hooks commands
+var Files embed.FS

--- a/plugins/provenance/hooks/hooks.json
+++ b/plugins/provenance/hooks/hooks.json
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-edit.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/post-commit.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/provenance/hooks/post-commit.sh
+++ b/plugins/provenance/hooks/post-commit.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# PostToolUse on Bash (5d): the commit-boundary gate. The git commit-msg/pre-commit
+# hook is the REAL gate; this fires after a `git commit` ran and, only when that
+# commit FAILED on a provenance violation, surfaces the engine's exact remediation
+# as advisory feedback (hand the agent the fix, never a bare door). Quiet on success,
+# on non-commit bash, and on non-provenance failures. Never blocks.
+
+input=$(cat)
+command -v jq >/dev/null 2>&1 || exit 0
+command -v linespec >/dev/null 2>&1 || exit 0
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+# Content-level scope to git commit — tool matchers cannot see command text, so this
+# one filter is necessarily in-script.
+printf '%s' "$cmd" | grep -q 'git commit' || exit 0
+
+exit_code=$(printf '%s' "$input" | jq -r '.tool_output.exit_code // .tool_response.exit_code // 0')
+[ "$exit_code" != "0" ] || exit 0
+stderr=$(printf '%s' "$input" | jq -r '.tool_output.stderr // .tool_response.stderr // ""')
+# Only react to provenance-related rejections, not arbitrary commit failures.
+printf '%s' "$stderr" | grep -qiE 'provenance|prov-[0-9]|scope violation|commit tag' || exit 0
+
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty')
+[ -n "$cwd" ] && cd "$cwd" 2>/dev/null
+next=$(linespec provenance next --json 2>/dev/null) || exit 0
+reason=$(printf '%s' "$next" | jq -r '.primary.reason // empty')
+[ -n "$reason" ] || exit 0
+ncmd=$(printf '%s' "$next" | jq -r '.primary.command // empty')
+
+msg="Provenance blocked this commit. Next: ${reason}"
+[ -n "$ncmd" ] && msg="${msg}"$'\n'"  ${ncmd}"
+
+jq -n --arg ctx "$msg" \
+  '{systemMessage: $ctx, hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $ctx}}'
+exit 0

--- a/plugins/provenance/hooks/pre-edit.sh
+++ b/plugins/provenance/hooks/pre-edit.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# PreToolUse on Edit|Write (5c): on the FIRST edit of a file per session, inject the
+# ACTIVE records that govern it (open + implemented; superseded/deprecated excluded)
+# plus the next suggestion. Advisory only — it injects context and NEVER blocks the
+# edit. Silent when no active record governs the file (the common case). Degrades
+# silently when jq/linespec are absent.
+
+input=$(cat)
+command -v jq >/dev/null 2>&1 || exit 0
+command -v linespec >/dev/null 2>&1 || exit 0
+
+file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
+[ -n "$file" ] || exit 0
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty')
+[ -n "$cwd" ] && cd "$cwd" 2>/dev/null
+[ -f ".linespec.yml" ] || exit 0
+
+# Dedup per file per session via a marker under the per-session data dir (NOT the
+# immutable plugin root) so the hook speaks at most once per file.
+session=$(printf '%s' "$input" | jq -r '.session_id // "nosession"')
+data_dir="${CLAUDE_PLUGIN_DATA:-${TMPDIR:-/tmp}}/linespec-provenance/${session}"
+mkdir -p "$data_dir" 2>/dev/null || exit 0
+marker="${data_dir}/$(printf '%s' "$file" | tr '/' '_')"
+[ -e "$marker" ] && exit 0
+: > "$marker" 2>/dev/null || true
+
+# govern matches repo-relative scope; strip the cwd prefix from the absolute path.
+rel="${file#"$cwd"/}"
+gov=$(linespec provenance govern --files "$rel" --json 2>/dev/null) || exit 0
+count=$(printf '%s' "$gov" | jq -r '.governing | length' 2>/dev/null || echo 0)
+[ "$count" -gt 0 ] 2>/dev/null || exit 0
+
+# Keep it signal, not noise: name the OPEN records (the ones you might tag) and
+# summarize sealed records as a count — a governed file can have dozens of sealed
+# records, and listing them all is exactly the over-gating noise to avoid.
+open_ids=$(printf '%s' "$gov" | jq -r '[.governing[] | select(.status=="open") | .id] | join(", ")')
+impl_count=$(printf '%s' "$gov" | jq -r '[.governing[] | select(.status=="implemented")] | length')
+if [ -n "$open_ids" ]; then
+  msg="Provenance — ${rel} is governed by open record(s): ${open_ids}. Tag your commit with one (no supersede needed)."
+  [ "$impl_count" -gt 0 ] 2>/dev/null && msg="${msg} (${impl_count} sealed record(s) also govern it — no action needed.)"
+else
+  msg="Provenance — ${rel} is governed by ${impl_count} sealed record(s). Make your change under your own record and tag your commits with it; do NOT supersede."
+fi
+nreason=$(printf '%s' "$gov" | jq -r '.next.reason // empty')
+ncmd=$(printf '%s' "$gov" | jq -r '.next.command // empty')
+[ -n "$nreason" ] && msg="${msg}"$'\n'"Next: ${nreason}"
+[ -n "$ncmd" ] && msg="${msg}"$'\n'"  ${ncmd}"
+
+# Advisory context only — no permissionDecision, so the normal permission flow proceeds.
+jq -n --arg ctx "$msg" \
+  '{hookSpecificOutput: {hookEventName: "PreToolUse", additionalContext: $ctx}}'
+exit 0

--- a/plugins/provenance/hooks/session-start.sh
+++ b/plugins/provenance/hooks/session-start.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SessionStart (5b): inject the ambient next provenance action once per session.
+# Thin renderer — all guidance comes from `linespec provenance next`. Degrades
+# silently (exit 0, no output) when jq/linespec are absent or this is not a
+# provenance repo, so it can never disrupt a session.
+
+input=$(cat)
+command -v jq >/dev/null 2>&1 || exit 0
+command -v linespec >/dev/null 2>&1 || exit 0
+
+cwd=$(printf '%s' "$input" | jq -r '.cwd // empty')
+[ -n "$cwd" ] || exit 0
+cd "$cwd" 2>/dev/null || exit 0
+[ -f ".linespec.yml" ] || exit 0
+
+next=$(linespec provenance next --json 2>/dev/null) || exit 0
+reason=$(printf '%s' "$next" | jq -r '.primary.reason // empty')
+[ -n "$reason" ] || exit 0
+cmd=$(printf '%s' "$next" | jq -r '.primary.command // empty')
+
+ctx="Provenance — next action: ${reason}"
+[ -n "$cmd" ] && ctx="${ctx}"$'\n'"  ${cmd}"
+
+jq -n --arg ctx "$ctx" \
+  '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+exit 0

--- a/provenance/prov-2026-007c8893.yml
+++ b/provenance/prov-2026-007c8893.yml
@@ -1,6 +1,6 @@
 id: prov-2026-007c8893
 title: 'Cached scope index for sub-200ms context/next lookups (Phase 5a)'
-status: open
+status: implemented
 created_at: "2026-06-12"
 author: test@example.com
 intent: |
@@ -62,7 +62,7 @@ supersedes: ""
 superseded_by: ""
 related:
   - prov-2026-54aaf9cf
-sealed_at_sha: ""
+sealed_at_sha: e13403af0d52eeddf61b2040f4561b2617d299fe
 associated_specs:
   - path: pkg/provenance/scope_index_test.go
     type: go_test

--- a/provenance/prov-2026-007c8893.yml
+++ b/provenance/prov-2026-007c8893.yml
@@ -1,6 +1,6 @@
 id: prov-2026-007c8893
 title: 'Cached scope index for sub-200ms context/next lookups (Phase 5a)'
-status: draft
+status: open
 created_at: "2026-06-12"
 author: test@example.com
 intent: |
@@ -56,7 +56,10 @@ superseded_by: ""
 related:
   - prov-2026-54aaf9cf
 sealed_at_sha: ""
-associated_specs: []
+associated_specs:
+  - path: pkg/provenance/scope_index_test.go
+    type: go_test
+    run_command: make test # {{path}}
 associated_traces: []
 monitors: []
 tags:

--- a/provenance/prov-2026-007c8893.yml
+++ b/provenance/prov-2026-007c8893.yml
@@ -55,6 +55,7 @@ affected_scope:
   - pkg/provenance/commands.go
   - cmd/linespec/main_stable.go
   - cmd/linespec/main_beta.go
+  - .gitignore
 forbidden_scope: []
 type: blueprint
 supersedes: ""

--- a/provenance/prov-2026-007c8893.yml
+++ b/provenance/prov-2026-007c8893.yml
@@ -1,0 +1,65 @@
+id: prov-2026-007c8893
+title: 'Cached scope index for sub-200ms context/next lookups (Phase 5a)'
+status: draft
+created_at: "2026-06-12"
+author: test@example.com
+intent: |
+  Foundation for the Phase 5 Claude Code plugin (the hooks, 5b-5d, are deferred to a
+  follow-up blueprint). Today every CLI invocation calls Loader.LoadAll(), walking and
+  parsing all ~318 YAML records. That is too slow to sit in a per-edit Claude Code hook
+  (sub-200ms budget), and it is wasted work for the common case of a single per-file
+  governance lookup.
+
+  Build a cached scope index so `context` and `next` per-file lookups are fast and
+  hook-safe, with correctness identical to the uncached path:
+
+  - Persist a compact index in .linespec/ (mirroring the existing schema-cache.json
+    hash+data pattern): per record, the minimum needed for governance/advice —
+    id, status, type, affected_scope, forbidden_scope, and whether it has
+    associated_specs. Heavy fields (intent, constraints prose) are not cached.
+  - Invalidate with a CHEAP fingerprint of the provenance dir: a hash of
+    (filename, size, mtime) tuples across the record files — stat only, no file reads.
+    On a fingerprint match, serve lookups from the cache without LoadAll. On a mismatch,
+    rebuild from LoadAll and repersist. Lazy and self-healing; no manual invalidation.
+  - On ANY doubt — fingerprint mismatch mid-flight, malformed cache, read/parse error,
+    or a feature the cache cannot answer — fall back to the authoritative LoadAll path.
+    The cache is an optimization, never a source of truth for governance decisions.
+
+  This standalone piece also speeds up context/next for everyone, not just the plugin.
+
+  DEFERRED (separate blueprint): the plugin hooks (5b SessionStart, 5c PreToolUse on
+  Edit/Write, 5d commit-boundary gate), all rendering the Phase 2 engine. Per the user,
+  that plugin must be installable BOTH ways — a `linespec` install command (mirroring
+  install-skill) AND a marketplace-style .claude-plugin/plugin.json.
+constraints:
+  - Cached context/next per-file lookups must be sub-200ms and must not perform a full
+    LoadAll on a cache hit.
+  - Cached output must be byte-identical to the current uncached context/next output for
+    the same state; a regression test asserts cached == uncached.
+  - The cache self-invalidates via a cheap stat-based fingerprint (no record-file reads
+    to check freshness); a stale cache rebuilds transparently on next use.
+  - The cache must never serve wrong governance — on any mismatch, malformed/missing
+    cache, or read error, fall back to the authoritative LoadAll path.
+  - The cache file lives under .linespec/ alongside the existing cache artifacts and is
+    safe to delete at any time (it simply rebuilds).
+  - No behavioral change to any command other than the internal source of context/next
+    lookups; enforcement, lint, and completion paths are untouched.
+  - make test must pass.
+affected_scope:
+  - pkg/provenance/scope_index.go
+  - pkg/provenance/scope_index_test.go
+  - pkg/provenance/commands.go
+forbidden_scope: []
+type: blueprint
+supersedes: ""
+superseded_by: ""
+related:
+  - prov-2026-54aaf9cf
+sealed_at_sha: ""
+associated_specs: []
+associated_traces: []
+monitors: []
+tags:
+  - agent-guidance
+  - phase-5
+  - cache

--- a/provenance/prov-2026-007c8893.yml
+++ b/provenance/prov-2026-007c8893.yml
@@ -32,10 +32,14 @@ intent: |
   that plugin must be installable BOTH ways — a `linespec` install command (mirroring
   install-skill) AND a marketplace-style .claude-plugin/plugin.json.
 constraints:
-  - Cached context/next per-file lookups must be sub-200ms and must not perform a full
-    LoadAll on a cache hit.
-  - Cached output must be byte-identical to the current uncached context/next output for
-    the same state; a regression test asserts cached == uncached.
+  - The cached `next` fast path must be sub-200ms and must not perform a full LoadAll on
+    a cache hit; the dispatch consults the cache before constructing the heavy,
+    eager-loading Commands.
+  - Cached `next` output must be byte-identical to the current uncached `next` output for
+    the same state; a regression test asserts cached == uncached. (The full `context`
+    rich output renders prose the compact cache intentionally omits, so `context` keeps
+    its heavy path here; the lightweight per-file `context` lookup the hooks need —
+    IDs/status only — lands with the hooks blueprint, consuming this same primitive.)
   - The cache self-invalidates via a cheap stat-based fingerprint (no record-file reads
     to check freshness); a stale cache rebuilds transparently on next use.
   - The cache must never serve wrong governance — on any mismatch, malformed/missing
@@ -49,6 +53,8 @@ affected_scope:
   - pkg/provenance/scope_index.go
   - pkg/provenance/scope_index_test.go
   - pkg/provenance/commands.go
+  - cmd/linespec/main_stable.go
+  - cmd/linespec/main_beta.go
 forbidden_scope: []
 type: blueprint
 supersedes: ""

--- a/provenance/prov-2026-01b4026c.yml
+++ b/provenance/prov-2026-01b4026c.yml
@@ -1,0 +1,51 @@
+id: prov-2026-01b4026c
+title: Route commit-violation hint and stale-scope warning through engine-owned wording (Phase 2c)
+status: draft
+created_at: "2026-06-11"
+author: test@example.com
+intent: |
+  Implements prov-2026-54aaf9cf (Phase 2c). Kills "skill says X but CLI prints Y"
+  drift by making the advice engine the SINGLE owner of the create-not-supersede
+  wording, then having every error-hint site render from it.
+
+  The two sites that previously carried their own hand-written copies of the
+  Phase 1 framing:
+    - formatter.go FormatCheckResult — the commit-violation "Hint:" lines.
+    - git.go buildStaleScopeWarnings — the non-blocking stale-scope message.
+
+  Change: next.go gains exported canonical-wording functions
+  (HintCreateNotSupersede, HintStaleScope) that the engine itself uses for the
+  create advice. formatter.go and git.go call those functions instead of inlining
+  the text. A blocked agent (hit the commit hook) and a proactive agent (ran
+  `next`) now read identical, single-sourced advice.
+constraints:
+  - This is a wording-routing change only — no enforcement severity or control-flow
+    change. The stale-scope warning stays non-blocking; the violation hint stays a
+    hint on an already-failing check.
+  - The canonical create-not-supersede wording exists in exactly one place
+    (next.go); formatter.go and git.go must not re-inline it.
+  - The stale-scope message keeps its per-file/per-record specificity (file, record
+    ID, sealed SHA) while sourcing its wording from the engine.
+  - A unit test asserts the canonical hint never presents `--supersedes` as the
+    default remedy and frames supersede as the deliberate-revision branch only.
+affected_scope:
+  - pkg/provenance/next.go
+  - pkg/provenance/next_test.go
+  - pkg/provenance/formatter.go
+  - pkg/provenance/git.go
+forbidden_scope: []
+type: imprint
+implements: prov-2026-54aaf9cf
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs:
+  - path: pkg/provenance/next_test.go
+    type: go_test
+    run_command: make test # {{path}}
+associated_traces: []
+monitors: []
+tags:
+  - agent-guidance
+  - phase-2

--- a/provenance/prov-2026-01b4026c.yml
+++ b/provenance/prov-2026-01b4026c.yml
@@ -1,6 +1,6 @@
 id: prov-2026-01b4026c
 title: Route commit-violation hint and stale-scope warning through engine-owned wording (Phase 2c)
-status: open
+status: implemented
 created_at: "2026-06-11"
 author: test@example.com
 intent: |
@@ -39,7 +39,7 @@ implements: prov-2026-54aaf9cf
 supersedes: ""
 superseded_by: ""
 related: []
-sealed_at_sha: ""
+sealed_at_sha: 73f60339c9466de16d9554ee8d97ca71ce92da24
 associated_specs:
   - path: pkg/provenance/next_test.go
     type: go_test

--- a/provenance/prov-2026-01b4026c.yml
+++ b/provenance/prov-2026-01b4026c.yml
@@ -1,6 +1,6 @@
 id: prov-2026-01b4026c
 title: Route commit-violation hint and stale-scope warning through engine-owned wording (Phase 2c)
-status: draft
+status: open
 created_at: "2026-06-11"
 author: test@example.com
 intent: |

--- a/provenance/prov-2026-21e9f419.yml
+++ b/provenance/prov-2026-21e9f419.yml
@@ -65,6 +65,7 @@ affected_scope:
   - pkg/provenance/overlap_specs_test.go
   - cmd/linespec/main_stable.go
   - cmd/linespec/main_beta.go
+  - .linespec.yml
 forbidden_scope: []
 type: blueprint
 supersedes: ""

--- a/provenance/prov-2026-21e9f419.yml
+++ b/provenance/prov-2026-21e9f419.yml
@@ -1,0 +1,81 @@
+id: prov-2026-21e9f419
+title: Make completion-time overlap teeth configurable (block|warn|off) and skip remote records
+status: draft
+created_at: "2026-06-11"
+author: test@example.com
+intent: |
+  Refines the Phase 3/4 governance-overlap teeth from prov-2026-bc57fbdc. Today the
+  teeth (running OTHER sealed records' associated_specs at completion) have exactly
+  one coarse control — run_associated_specs_on_complete — which is all-or-nothing and
+  also gates the completing record's OWN spec proof. In practice this is too blunt:
+  because broad CLI files (cmd/linespec/main_stable.go, main_beta.go,
+  pkg/provenance/commands.go, git.go) sit in nearly every record's scope, completing
+  any record that touches them runs the ENTIRE examples/*-linespecs Docker integration
+  matrix (10+ minutes, requires Docker), and a single flaky integration spec rolls back
+  an otherwise-correct, unrelated completion. This was observed live completing
+  prov-2026-54aaf9cf: it rolled back once on a flaky spec, then passed unchanged on
+  retry.
+
+  Two changes:
+
+  (1) Tri-state severity for the overlap teeth via a new config key
+  `overlap_specs_on_complete: block | warn | off` (default `block` — current behavior,
+  fully backward compatible):
+    - block: run touched sealed records' specs; on failure roll back the completion
+      atomically (today's behavior).
+    - warn:  run them; on failure emit a non-blocking FYI naming the records/specs and
+      PROCEED with completion (no rollback).
+    - off:   skip the overlap teeth entirely. The completing record's OWN
+      associated_specs still run (still gated by run_associated_specs_on_complete);
+      only the cross-record teeth are skipped.
+  This mirrors the existing `enforcement: none|warn|strict` tri-state, so a team can
+  dial the teeth down as a maintainer/settings decision rather than agents brute-forcing
+  past them. run_associated_specs_on_complete remains the master switch for completion
+  spec-running generally; when it is false, nothing runs regardless of this key.
+
+  (2) Skip remote (shared_repos cache) records in the overlap selectors. A remote
+  sealed record's associated_specs paths are relative to ITS origin repo and may not
+  resolve in this working tree, so running them here can produce a false failure that
+  rolls back an unrelated completion. Remote records are read-only here and cannot be
+  superseded locally, so they must not gate local completion. Applies to both the
+  completion-time selector (overlappingSealedRecords) and the open-time heads-up
+  (declaredOverlapSealedRecords).
+constraints:
+  - Default behavior (no config key set, or `block`) must be byte-for-byte identical to
+    today's teeth — run overlapping sealed records' specs, roll back atomically on
+    failure. Existing tests must still pass unchanged.
+  - The `warn` mode runs the teeth but converts a spec failure into a non-blocking FYI
+    and completes; `off` skips the teeth selection/run entirely while leaving the
+    completing record's own-spec verification intact.
+  - The new key is gated under run_associated_specs_on_complete — when that master
+    switch is false, no completion specs run (own or overlap), preserving current
+    behavior.
+  - An invalid value for overlap_specs_on_complete is rejected (or defaulted to block
+    with a clear notice), never silently treated as off.
+  - Remote (cache-sourced) records are excluded from BOTH overlap selectors; a local
+    completion is never blocked or warned by a record this repo cannot modify.
+  - The config key must be plumbed through pkg/config types AND mapped into the
+    provenance ProvenanceConfig in BOTH cmd/linespec/main_stable.go and main_beta.go.
+  - Unit tests cover all modes — block (fail rolls back), warn (fail becomes FYI and
+    completes), off (teeth skipped, own specs still run), and remote-record exclusion.
+  - make test must pass.
+affected_scope:
+  - pkg/config/types.go
+  - pkg/provenance/commands.go
+  - pkg/provenance/overlap_specs_test.go
+  - cmd/linespec/main_stable.go
+  - cmd/linespec/main_beta.go
+forbidden_scope: []
+type: blueprint
+supersedes: ""
+superseded_by: ""
+related:
+  - prov-2026-bc57fbdc
+sealed_at_sha: ""
+associated_specs: []
+associated_traces: []
+monitors: []
+tags:
+  - provenance-ux
+  - governance-overlap
+  - config

--- a/provenance/prov-2026-21e9f419.yml
+++ b/provenance/prov-2026-21e9f419.yml
@@ -1,6 +1,6 @@
 id: prov-2026-21e9f419
 title: Make completion-time overlap teeth configurable (block|warn|off) and skip remote records
-status: open
+status: implemented
 created_at: "2026-06-11"
 author: test@example.com
 intent: |
@@ -72,7 +72,7 @@ supersedes: ""
 superseded_by: ""
 related:
   - prov-2026-bc57fbdc
-sealed_at_sha: ""
+sealed_at_sha: 606de82c67929f44559648ad2149ba509b4a4bd3
 associated_specs:
   - path: pkg/provenance/overlap_specs_test.go
     type: go_test

--- a/provenance/prov-2026-21e9f419.yml
+++ b/provenance/prov-2026-21e9f419.yml
@@ -1,6 +1,6 @@
 id: prov-2026-21e9f419
 title: Make completion-time overlap teeth configurable (block|warn|off) and skip remote records
-status: draft
+status: open
 created_at: "2026-06-11"
 author: test@example.com
 intent: |
@@ -72,7 +72,10 @@ superseded_by: ""
 related:
   - prov-2026-bc57fbdc
 sealed_at_sha: ""
-associated_specs: []
+associated_specs:
+  - path: pkg/provenance/overlap_specs_test.go
+    type: go_test
+    run_command: make test # {{path}}
 associated_traces: []
 monitors: []
 tags:

--- a/provenance/prov-2026-2f9f0620.yml
+++ b/provenance/prov-2026-2f9f0620.yml
@@ -1,0 +1,56 @@
+id: prov-2026-2f9f0620
+title: 'Scope-index implementation: stat fingerprint, .linespec/scope-index.json, dispatch fast path for next via lightweight Commands'
+status: draft
+created_at: "2026-06-12"
+author: test@example.com
+intent: |
+  Implements prov-2026-007c8893 (Phase 5a). Concrete implementation decisions:
+
+  - scope_index.go: ScopeEntry{ID, Status, Type, AffectedScope, ForbiddenScope,
+    Implements, HasSpecs} — only the fields the advice engine reads. ScopeIndex
+    {Fingerprint, Entries} persists as JSON in .linespec/scope-index.json (alongside
+    schema-cache.json / hash_manifest.json).
+  - Fingerprint = sha256 over sorted "relpath\0size\0modUnixNano" tuples of every *.yml
+    across the loader's directories (local provenance dir + shared cache dirs). Stat
+    only, no file reads — fast freshness check.
+  - ScopeEntry.toRecord() reconstructs a lightweight *Record carrying exactly those
+    fields (AssociatedSpecs synthesized to length 1 when HasSpecs, since Advise only
+    checks len). These drive Advise identically to full records.
+  - The dispatch (main_stable.go + main_beta.go) `next` case tries loadFreshScopeIndex
+    BEFORE NewCommands. On a fingerprint match it builds a lightweight Commands (Loader
+    pre-populated from entries, NO LoadAll) and runs Next — skipping the ~318-file parse.
+    On any miss/stale/error it falls through to the normal heavy NewCommands path, which
+    refreshes the cache after loading.
+  - NewCommandsWithEmbedder writes/refreshes the cache after its LoadAll (cheap,
+    idempotent when already fresh), so normal CLI usage keeps the cache warm for the
+    fast path.
+  - The cache is advisory: any malformed/missing cache or fingerprint mismatch falls
+    back to LoadAll. It is never a governance source of truth.
+constraints:
+  - Fast-path next must reconstruct records carrying every field Advise reads
+    (Status, Type, AffectedScope, ForbiddenScope, Implements, has-specs).
+  - On any cache problem, fall back to the heavy path — never serve from a stale/corrupt
+    cache.
+  - cached next output == uncached next output (asserted by test).
+affected_scope:
+  - pkg/provenance/scope_index.go
+  - pkg/provenance/scope_index_test.go
+  - pkg/provenance/commands.go
+  - cmd/linespec/main_stable.go
+  - cmd/linespec/main_beta.go
+forbidden_scope: []
+type: imprint
+implements: prov-2026-007c8893
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs:
+  - path: pkg/provenance/scope_index_test.go
+    type: go_test
+    run_command: make test # {{path}}
+associated_traces: []
+monitors: []
+tags:
+  - phase-5
+  - cache

--- a/provenance/prov-2026-2f9f0620.yml
+++ b/provenance/prov-2026-2f9f0620.yml
@@ -1,6 +1,6 @@
 id: prov-2026-2f9f0620
 title: 'Scope-index implementation: stat fingerprint, .linespec/scope-index.json, dispatch fast path for next via lightweight Commands'
-status: open
+status: implemented
 created_at: "2026-06-12"
 author: test@example.com
 intent: |
@@ -44,7 +44,7 @@ implements: prov-2026-007c8893
 supersedes: ""
 superseded_by: ""
 related: []
-sealed_at_sha: ""
+sealed_at_sha: 4087890ec42c3762f003151a1c6b5ca0bfe03210
 associated_specs:
   - path: pkg/provenance/scope_index_test.go
     type: go_test

--- a/provenance/prov-2026-2f9f0620.yml
+++ b/provenance/prov-2026-2f9f0620.yml
@@ -1,6 +1,6 @@
 id: prov-2026-2f9f0620
 title: 'Scope-index implementation: stat fingerprint, .linespec/scope-index.json, dispatch fast path for next via lightweight Commands'
-status: draft
+status: open
 created_at: "2026-06-12"
 author: test@example.com
 intent: |

--- a/provenance/prov-2026-54aaf9cf.yml
+++ b/provenance/prov-2026-54aaf9cf.yml
@@ -1,0 +1,87 @@
+id: prov-2026-54aaf9cf
+title: Build the 'next' advice engine and 'linespec provenance next' command (Phase 2)
+status: draft
+created_at: "2026-06-11"
+author: test@example.com
+intent: |
+  Replace error-driven navigation with computed, state-aware guidance. Build ONE
+  engine that answers: "given the current provenance state (and optionally the
+  files I intend to change), what is the correct next action?" Every guidance
+  surface — the new `next` command, the CLI error hints, the skill, and any future
+  plugin — renders from this single engine. This permanently kills "skill says X
+  but the CLI prints Y" drift: guidance only has to be correct in one place.
+
+  This is the keystone of the larger agent-guidance effort. Phase 1 (rewording the
+  supersede-only messages + skill happy-path) already shipped; this phase makes the
+  guidance computed rather than hand-written per call site.
+
+  Three parts:
+
+  (2a) Advice engine. A pure function: (current state [, intended files]) ->
+  ordered next action(s) with concrete record IDs filled in. State = records +
+  statuses (Loader.LoadAll), staged files (Git.GetStagedFiles), branch diff
+  (Git.DiffFiles). The function has no side effects and does no I/O itself — state
+  is gathered by the caller and passed in, so it is unit-testable in isolation.
+  Output covers at least these state branches:
+    - no governing record for the intended/changed files -> `create`
+    - a draft record exists -> `open` it
+    - an open record with no associated_specs -> add an associated_spec (show shape)
+    - an open record, specs present, changes staged -> commit tagged [prov-...]
+    - all imprints of a blueprint implemented -> `complete` the blueprint
+
+  (2b) Expose as `linespec provenance next`:
+    - `next` (ambient) -> reads current state, prints the single correct command.
+    - `next --files X Y` (alias `--plan`) -> intent-aware; folds a context lookup
+      per named file so governance surfaces during planning, before editing.
+    - `--json` -> machine-readable output for hook/agent consumption.
+
+  (2c) Route the existing error hints through the same engine, so a blocked agent
+  (hit an enforcement wall) and a proactive agent (asked `next`) receive identical
+  advice. The reworded Phase 1 strings become renderings of the engine output, not
+  independent hand-written text.
+constraints:
+  - The advice engine MUST be a pure function with no I/O and no side effects — it
+    receives already-gathered state (records, statuses, staged files, diff,
+    optional intended-files) and returns ordered actions. This is what makes it
+    unit-testable and reusable across every surface.
+  - There must be exactly ONE engine. The `next` command, the CLI error hints
+    (2c), and any later surface must all render from it — no second copy of the
+    decision logic anywhere.
+  - From any provenance state, `next` prints the single correct next command with
+    real record IDs substituted (not a placeholder). The same text must appear
+    whether the advice was reached via an enforcement error or via asking `next`.
+  - The `next --files`/`--plan` form must surface governing records for the named
+    files using the existing context lookup, and must NOT recommend superseding
+    records that merely govern those files (consistent with Phase 1 framing).
+  - The `--json` output must be stable and machine-consumable (documented shape),
+    since Phase 5 hooks will depend on it.
+  - The `next` subcommand must be wired into BOTH cmd/linespec/main_stable.go and
+    cmd/linespec/main_beta.go dispatch (kept in sync), following the existing
+    parse<Cmd>Options + cmds.<Cmd>(opts) pattern.
+  - Phase 2 must not change enforcement severity or control flow of the existing
+    checks; routing hints through the engine (2c) reproduces the current Phase 1
+    wording as engine output, it does not newly block or unblock anything.
+  - Engine behavior must be covered by Go unit tests asserting the correct action
+    for each state branch listed in the intent.
+affected_scope:
+  - pkg/provenance/next.go
+  - pkg/provenance/next_test.go
+  - pkg/provenance/commands.go
+  - pkg/provenance/formatter.go
+  - pkg/provenance/git.go
+  - cmd/linespec/main_stable.go
+  - cmd/linespec/main_beta.go
+forbidden_scope: []
+type: blueprint
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs: []
+associated_traces: []
+monitors: []
+tags:
+  - agent-guidance
+  - provenance-ux
+  - phase-2
+  - keystone

--- a/provenance/prov-2026-54aaf9cf.yml
+++ b/provenance/prov-2026-54aaf9cf.yml
@@ -1,6 +1,6 @@
 id: prov-2026-54aaf9cf
 title: Build the 'next' advice engine and 'linespec provenance next' command (Phase 2)
-status: open
+status: implemented
 created_at: "2026-06-11"
 author: test@example.com
 intent: |
@@ -76,7 +76,7 @@ type: blueprint
 supersedes: ""
 superseded_by: ""
 related: []
-sealed_at_sha: ""
+sealed_at_sha: bf753efa567a21ae32ec68801945a10756375156
 associated_specs:
   - path: pkg/provenance/next_test.go
     type: go_test

--- a/provenance/prov-2026-54aaf9cf.yml
+++ b/provenance/prov-2026-54aaf9cf.yml
@@ -1,6 +1,6 @@
 id: prov-2026-54aaf9cf
 title: Build the 'next' advice engine and 'linespec provenance next' command (Phase 2)
-status: draft
+status: open
 created_at: "2026-06-11"
 author: test@example.com
 intent: |
@@ -77,7 +77,10 @@ supersedes: ""
 superseded_by: ""
 related: []
 sealed_at_sha: ""
-associated_specs: []
+associated_specs:
+  - path: pkg/provenance/next_test.go
+    type: go_test
+    run_command: make test # {{path}}
 associated_traces: []
 monitors: []
 tags:

--- a/provenance/prov-2026-5c310d9d.yml
+++ b/provenance/prov-2026-5c310d9d.yml
@@ -1,0 +1,75 @@
+id: prov-2026-5c310d9d
+title: Document next/govern/install-plugin commands, overlap_specs_on_complete config, and the Claude Code plugin across docs + doc site
+status: draft
+created_at: "2026-06-12"
+author: test@example.com
+intent: |
+  The agent-guidance effort added user-facing surfaces that are not yet documented.
+  Update every reference doc and the doc site so they describe, code-verified, what
+  shipped:
+
+  New CLI commands:
+   - `linespec provenance next` — computed next provenance action (ambient, --files /
+     --plan for intent-aware planning, --json for hooks/agents). Cache-backed fast path.
+   - `linespec provenance govern` — active-only (open + implemented) per-file
+     governance lookup, --files / --json. Cache-backed; excludes superseded/deprecated.
+   - `linespec provenance install-plugin` — installs the Claude Code provenance plugin.
+
+  New configuration:
+   - `overlap_specs_on_complete: block | warn | off` in .linespec.yml (default block) —
+     severity of the completion-time cross-record overlap teeth. Document alongside
+     run_associated_specs_on_complete (the master switch).
+
+  New artifact / behavior:
+   - The Claude Code provenance plugin (plugins/provenance/): SessionStart guidance,
+     per-edit governance (PreToolUse), commit remediation (PostToolUse), a
+     /provenance-next slash command. Dual install — the install-plugin command AND a
+     marketplace .claude-plugin/plugin.json (`claude plugin install`).
+   - The scope cache (.linespec/scope-index.json) backing next/govern, mentioned where
+     the other .linespec cache artifacts are described (gitignored, self-healing).
+
+  Cover all the places these are already referenced: the doc-site pages (index,
+  provenance, and linespec config section), the LLM docs (llms.txt, llms-full.txt),
+  and the markdown references (PROVENANCE_RECORDS, PROVENANCE_RECORD_SCHEMA, README,
+  CLAUDE), plus a CHANGELOG entry under [Unreleased].
+constraints:
+  - Content must be code-verified — command flags, the config key/values, and the
+    plugin layout must match what actually shipped (do not invent flags or defaults).
+  - The default for overlap_specs_on_complete is block (current behavior); warn and off
+    are the opt-in downgrades. Note that --force does NOT bypass the teeth.
+  - Keep each surface in its existing style — HTML pages stay HTML, llms.txt stays its
+    terse format, markdown stays markdown; mirror the structure already used for the
+    neighboring commands/config keys.
+  - The new commands are documented next to the existing provenance subcommands; the
+    new config key next to run_associated_specs_on_complete; the plugin gets its own
+    short section near the skills/install-skills material.
+  - CHANGELOG gets a single [Unreleased] entry summarizing the additions; do NOT cut a
+    release or bump VERSION (release happens after merge).
+  - No code changes — documentation only.
+affected_scope:
+  - docs/index.html
+  - docs/provenance.html
+  - docs/linespec.html
+  - docs/llms.txt
+  - docs/llms-full.txt
+  - PROVENANCE_RECORDS.md
+  - PROVENANCE_RECORD_SCHEMA.md
+  - README.md
+  - CLAUDE.md
+  - CHANGELOG.md
+  - LINESPEC.md
+forbidden_scope: []
+type: blueprint
+supersedes: ""
+superseded_by: ""
+related:
+  - prov-2026-54aaf9cf
+  - prov-2026-21e9f419
+  - prov-2026-cd1405fb
+sealed_at_sha: ""
+associated_specs: []
+associated_traces: []
+monitors: []
+tags:
+  - docs
+  - agent-guidance

--- a/provenance/prov-2026-5c310d9d.yml
+++ b/provenance/prov-2026-5c310d9d.yml
@@ -1,6 +1,6 @@
 id: prov-2026-5c310d9d
 title: Document next/govern/install-plugin commands, overlap_specs_on_complete config, and the Claude Code plugin across docs + doc site
-status: open
+status: implemented
 created_at: "2026-06-12"
 author: test@example.com
 intent: |
@@ -66,7 +66,7 @@ related:
   - prov-2026-54aaf9cf
   - prov-2026-21e9f419
   - prov-2026-cd1405fb
-sealed_at_sha: ""
+sealed_at_sha: 717a117ce7ce01d4281454300a1e3e8dc6070ed4
 associated_specs:
   - path: PROVENANCE_RECORDS.md
     run_command: grep -q overlap_specs_on_complete {{path}}

--- a/provenance/prov-2026-5c310d9d.yml
+++ b/provenance/prov-2026-5c310d9d.yml
@@ -1,6 +1,6 @@
 id: prov-2026-5c310d9d
 title: Document next/govern/install-plugin commands, overlap_specs_on_complete config, and the Claude Code plugin across docs + doc site
-status: draft
+status: open
 created_at: "2026-06-12"
 author: test@example.com
 intent: |
@@ -67,7 +67,11 @@ related:
   - prov-2026-21e9f419
   - prov-2026-cd1405fb
 sealed_at_sha: ""
-associated_specs: []
+associated_specs:
+  - path: PROVENANCE_RECORDS.md
+    run_command: grep -q overlap_specs_on_complete {{path}}
+  - path: README.md
+    run_command: grep -q 'provenance next' {{path}}
 associated_traces: []
 monitors: []
 tags:

--- a/provenance/prov-2026-7d609df8.yml
+++ b/provenance/prov-2026-7d609df8.yml
@@ -1,0 +1,60 @@
+id: prov-2026-7d609df8
+title: Reword supersede-only guidance messages and update provenance skill (Phase 1)
+status: draft
+created_at: "2026-06-11"
+author: test@example.com
+intent: |
+  Stop agents and humans from getting trapped in provenance enforcement by
+  misreading supersede-oriented guidance as a hard block. Origin: an advanced
+  model spent ~$400 misreading the non-blocking stale-scope warning as a hard
+  block and concluding it had to supersede ~11 sealed records.
+
+  Phase 1 is the cheap, high-impact, recurrence-preventing slice that ships
+  independently of the later engine/plugin work. It does two things:
+
+  (1a) Reword the three messages that hard-code `--supersedes` as the default
+  remedy so each presents the correct branch: touching a file governed by an
+  implemented record does NOT require superseding. Supersede is only for
+  deliberately revising the captured decision. The stale-scope warning keeps its
+  loud non-blocking label.
+
+  (1b) Update the agent-facing provenance skill so the decision tree includes the
+  exact stale-scope warning string (currently absent), a positive happy-path
+  recipe, a worked associated_specs example showing order of operations, and a
+  cross-link to the linespec-testing skill.
+constraints:
+  - The stale-scope warning (git.go) must remain non-blocking and keep its loud
+    "(non-blocking)" label; only its wording changes.
+  - No message may present `--supersedes` as the default/first remedy for merely
+    touching a governed file. Supersede must be framed as the deliberate-revision
+    branch only.
+  - The locked-scope linter message (linter.go) is a real hard error and must stay
+    an error; only its wording changes to clarify supersede is the intentional
+    path to reopen a locked layer.
+  - These are string/documentation changes only — no control-flow, severity, or
+    enforcement behavior changes in Phase 1.
+  - The skill update must add the literal stale-scope warning string to the
+    decision tree, a top happy-path recipe (context -f per file -> create one
+    record -> set affected_scope -> open with a spec -> commit tagged -> complete),
+    a worked associated_specs example (create the proof file first, then reference
+    it), and a cross-link to the linespec-testing skill.
+  - A fresh agent given the incident's starting conditions must create one new
+    record covering its files and commit, without attempting supersession.
+affected_scope:
+  - pkg/provenance/git.go
+  - pkg/provenance/formatter.go
+  - pkg/provenance/linter.go
+  - .claude/skills/provenance/SKILL.md
+forbidden_scope: []
+type: blueprint
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs: []
+associated_traces: []
+monitors: []
+tags:
+  - agent-guidance
+  - provenance-ux
+  - phase-1

--- a/provenance/prov-2026-7d609df8.yml
+++ b/provenance/prov-2026-7d609df8.yml
@@ -1,6 +1,6 @@
 id: prov-2026-7d609df8
 title: Reword supersede-only guidance messages and update provenance skill (Phase 1)
-status: draft
+status: deprecated
 created_at: "2026-06-11"
 author: test@example.com
 intent: |
@@ -40,11 +40,7 @@ constraints:
     it), and a cross-link to the linespec-testing skill.
   - A fresh agent given the incident's starting conditions must create one new
     record covering its files and commit, without attempting supersession.
-affected_scope:
-  - pkg/provenance/git.go
-  - pkg/provenance/formatter.go
-  - pkg/provenance/linter.go
-  - .claude/skills/provenance/SKILL.md
+affected_scope: []
 forbidden_scope: []
 type: blueprint
 supersedes: ""

--- a/provenance/prov-2026-97326c74.yml
+++ b/provenance/prov-2026-97326c74.yml
@@ -1,6 +1,6 @@
 id: prov-2026-97326c74
 title: Active-only per-file governing lookup + govern command with cache fast path (Phase 5b-5d foundation)
-status: open
+status: implemented
 created_at: "2026-06-12"
 author: test@example.com
 intent: |
@@ -36,7 +36,7 @@ implements: prov-2026-cd1405fb
 supersedes: ""
 superseded_by: ""
 related: []
-sealed_at_sha: ""
+sealed_at_sha: 029764cd91cea4450edab4579f5d77293dc4096a
 associated_specs:
   - path: pkg/provenance/scope_index_test.go
     type: go_test

--- a/provenance/prov-2026-97326c74.yml
+++ b/provenance/prov-2026-97326c74.yml
@@ -1,6 +1,6 @@
 id: prov-2026-97326c74
 title: Active-only per-file governing lookup + govern command with cache fast path (Phase 5b-5d foundation)
-status: draft
+status: open
 created_at: "2026-06-12"
 author: test@example.com
 intent: |

--- a/provenance/prov-2026-97326c74.yml
+++ b/provenance/prov-2026-97326c74.yml
@@ -1,0 +1,48 @@
+id: prov-2026-97326c74
+title: Active-only per-file governing lookup + govern command with cache fast path (Phase 5b-5d foundation)
+status: draft
+created_at: "2026-06-12"
+author: test@example.com
+intent: |
+  Implements prov-2026-cd1405fb. The Go foundation the 5c hook calls.
+
+  - scope_index.go: activeGoverningRecords(records, files) returns records that are
+    open OR implemented AND explicitly govern (allowlist scope match) at least one
+    file. Reuses the existing explicitlyGoverns helper (same package) so it does NOT
+    modify the sealed Phase 2 next.go. Superseded/deprecated are excluded.
+  - commands.go: a Govern command + GovernOptions{Files, Format, ConfigFile} that
+    renders the active governing records for the given files, plus the engine's
+    primary next action (so the hook can end with a next suggestion). JSON shape is
+    stable for hook consumption: {files, governing:[{id,status}], next:{command,reason}}.
+  - scope_index.go: TryGovernFromCache mirrors TryNextFromCache — serves govern from
+    the cached scope index without a full LoadAll, falling back on any miss.
+  - main_stable.go + main_beta.go: a `govern` dispatch case, and the pre-NewCommands
+    fast-path call (alongside the existing `next` fast path).
+constraints:
+  - activeGoverningRecords excludes superseded and deprecated; only open + implemented
+    are returned. A unit test asserts this.
+  - The govern command is cache-backed via the 5a fast path and never pays a full
+    LoadAll on a cache hit; falls back to the authoritative path on any miss.
+  - The JSON shape is stable and documented (hooks depend on it).
+affected_scope:
+  - pkg/provenance/scope_index.go
+  - pkg/provenance/scope_index_test.go
+  - pkg/provenance/commands.go
+  - cmd/linespec/main_stable.go
+  - cmd/linespec/main_beta.go
+forbidden_scope: []
+type: imprint
+implements: prov-2026-cd1405fb
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs:
+  - path: pkg/provenance/scope_index_test.go
+    type: go_test
+    run_command: make test # {{path}}
+associated_traces: []
+monitors: []
+tags:
+  - phase-5
+  - claude-code-plugin

--- a/provenance/prov-2026-a053a867.yml
+++ b/provenance/prov-2026-a053a867.yml
@@ -1,6 +1,6 @@
 id: prov-2026-a053a867
 title: 'Advice engine design: pure Advise(NextState) with ordered precedence (Phase 2a)'
-status: draft
+status: open
 created_at: "2026-06-11"
 author: test@example.com
 intent: |
@@ -48,7 +48,10 @@ supersedes: ""
 superseded_by: ""
 related: []
 sealed_at_sha: ""
-associated_specs: []
+associated_specs:
+  - path: pkg/provenance/next_test.go
+    type: go_test
+    run_command: make test # {{path}}
 associated_traces: []
 monitors: []
 tags:

--- a/provenance/prov-2026-a053a867.yml
+++ b/provenance/prov-2026-a053a867.yml
@@ -1,6 +1,6 @@
 id: prov-2026-a053a867
 title: 'Advice engine design: pure Advise(NextState) with ordered precedence (Phase 2a)'
-status: open
+status: implemented
 created_at: "2026-06-11"
 author: test@example.com
 intent: |
@@ -47,7 +47,7 @@ implements: prov-2026-54aaf9cf
 supersedes: ""
 superseded_by: ""
 related: []
-sealed_at_sha: ""
+sealed_at_sha: 2c21de9944ad8a67c6bd96b3e57760fd5de6dfde
 associated_specs:
   - path: pkg/provenance/next_test.go
     type: go_test

--- a/provenance/prov-2026-a053a867.yml
+++ b/provenance/prov-2026-a053a867.yml
@@ -1,0 +1,56 @@
+id: prov-2026-a053a867
+title: 'Advice engine design: pure Advise(NextState) with ordered precedence (Phase 2a)'
+status: draft
+created_at: "2026-06-11"
+author: test@example.com
+intent: |
+  Records the design of the Phase 2a advice engine (implements prov-2026-54aaf9cf).
+
+  Shape: a pure function `Advise(state NextState) []NextAction`. NextState is an
+  already-gathered, side-effect-free snapshot (Records, StagedFiles, ChangedFiles,
+  optional IntendedFiles, CommitTagRequired). The engine does no I/O so it is
+  unit-testable and reusable from every surface (the `next` command, error hints,
+  hooks).
+
+  Precedence (first match wins; index 0 of the returned slice is the single
+  primary recommendation):
+    1. Determine relevant files = IntendedFiles, else StagedFiles ∪ ChangedFiles.
+    2. If exactly one OPEN top-level record (blueprint/bug) governs those files ->
+       that is the active record; advise on it (below). If more than one open
+       record governs -> ambiguous: advise working under/tagging one of them
+       (explicitly NOT supersede — Phase 1 framing).
+    3. Else if a DRAFT top-level record governs the files (or, ambient with a clean
+       tree, a lone draft exists) -> `open` it.
+    4. Else -> `create` a new blueprint covering the files. If sealed/implemented
+       records govern those files, list them as advisory governing records with a
+       note that they do NOT need superseding.
+
+  Advise-on-active record precedence:
+    a. No associated_specs -> add an associated_spec (show YAML shape). (Under
+       strict this is already enforced at open; matters under warn/none.)
+    b. Staged changes present -> commit them tagged `[<record-id>]`.
+    c. Unimplemented imprints implementing this blueprint -> complete the next one.
+    d. Otherwise (specs present, nothing staged, no pending imprints) -> complete
+       the blueprint.
+constraints:
+  - Advise must be a pure function — no filesystem, git, or network access inside it.
+  - The primary recommendation is element 0 of the returned slice; callers may show
+    follow-ups but must treat index 0 as THE next step.
+  - No branch may recommend supersede as the remedy for merely touching governed
+    files; supersede is only ever the deliberate-revision path (Phase 1 framing).
+affected_scope:
+  - pkg/provenance/next.go
+  - pkg/provenance/next_test.go
+forbidden_scope: []
+type: imprint
+implements: prov-2026-54aaf9cf
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs: []
+associated_traces: []
+monitors: []
+tags:
+  - agent-guidance
+  - phase-2

--- a/provenance/prov-2026-a4204f20.yml
+++ b/provenance/prov-2026-a4204f20.yml
@@ -1,6 +1,6 @@
 id: prov-2026-a4204f20
 title: 'Dual install: embed plugin files + linespec provenance install-plugin command + scripts/install-plugin (5b-5d)'
-status: draft
+status: open
 created_at: "2026-06-12"
 author: test@example.com
 intent: |

--- a/provenance/prov-2026-a4204f20.yml
+++ b/provenance/prov-2026-a4204f20.yml
@@ -1,6 +1,6 @@
 id: prov-2026-a4204f20
 title: 'Dual install: embed plugin files + linespec provenance install-plugin command + scripts/install-plugin (5b-5d)'
-status: open
+status: implemented
 created_at: "2026-06-12"
 author: test@example.com
 intent: |
@@ -40,7 +40,7 @@ implements: prov-2026-cd1405fb
 supersedes: ""
 superseded_by: ""
 related: []
-sealed_at_sha: ""
+sealed_at_sha: 99c3f282d510dafd34253f14507e838d6d349c95
 associated_specs:
   - path: pkg/provenance/scope_index_test.go
     type: go_test

--- a/provenance/prov-2026-a4204f20.yml
+++ b/provenance/prov-2026-a4204f20.yml
@@ -1,0 +1,52 @@
+id: prov-2026-a4204f20
+title: 'Dual install: embed plugin files + linespec provenance install-plugin command + scripts/install-plugin (5b-5d)'
+status: draft
+created_at: "2026-06-12"
+author: test@example.com
+intent: |
+  Implements prov-2026-cd1405fb. The two install paths the user asked for.
+
+  - plugins/provenance/embed.go: a tiny `plugin` package exposing an embed.FS of the
+    plugin tree (.claude-plugin, hooks, commands) via //go:embed, so the distributed
+    linespec binary carries the plugin files.
+  - commands.go: InstallPlugin(opts) walks that embed.FS and writes the plugin into the
+    target Claude Code config dir (default .claude/plugins/linespec-provenance),
+    preserving structure and re-applying the executable bit to *.sh hook scripts. It
+    creates only the plugin's own files — it does not touch unrelated user config.
+  - main_stable.go + main_beta.go: an `install-plugin` dispatch case + option parsing
+    (a target --path).
+  - scripts/install-plugin: a shell alternative that copies plugins/provenance/ into a
+    target dir, mirroring scripts/install-skill (for in-repo / non-binary use).
+
+  The marketplace path (option 3) needs no code beyond the imprint-2 plugin files and
+  the .claude-plugin/marketplace.json already shipped: users run
+  `claude plugin marketplace add` + `claude plugin install`.
+constraints:
+  - InstallPlugin writes only the plugin's files into the target; it never edits or
+    clobbers unrelated user Claude Code config.
+  - Executable bits are re-applied to *.sh after extraction (embed.FS drops file modes).
+  - The embedded plugin tree matches the on-disk plugins/provenance/ source.
+  - make test must pass; install is smoke-tested writing to a temp dir.
+affected_scope:
+  - plugins/provenance/embed.go
+  - pkg/provenance/commands.go
+  - pkg/provenance/scope_index_test.go
+  - cmd/linespec/main_stable.go
+  - cmd/linespec/main_beta.go
+  - scripts/install-plugin
+forbidden_scope: []
+type: imprint
+implements: prov-2026-cd1405fb
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs:
+  - path: pkg/provenance/scope_index_test.go
+    type: go_test
+    run_command: make test # {{path}}
+associated_traces: []
+monitors: []
+tags:
+  - phase-5
+  - claude-code-plugin

--- a/provenance/prov-2026-ba04fb6e.yml
+++ b/provenance/prov-2026-ba04fb6e.yml
@@ -1,6 +1,6 @@
 id: prov-2026-ba04fb6e
 title: 'Wire ''linespec provenance next'' command: state gathering, rendering, dual dispatch (Phase 2b)'
-status: draft
+status: open
 created_at: "2026-06-11"
 author: test@example.com
 intent: |

--- a/provenance/prov-2026-ba04fb6e.yml
+++ b/provenance/prov-2026-ba04fb6e.yml
@@ -1,6 +1,6 @@
 id: prov-2026-ba04fb6e
 title: 'Wire ''linespec provenance next'' command: state gathering, rendering, dual dispatch (Phase 2b)'
-status: open
+status: implemented
 created_at: "2026-06-11"
 author: test@example.com
 intent: |
@@ -40,7 +40,7 @@ implements: prov-2026-54aaf9cf
 supersedes: ""
 superseded_by: ""
 related: []
-sealed_at_sha: ""
+sealed_at_sha: f8ccc3ee61cebab45ee048ed69d748978b0ddb05
 associated_specs:
   - path: pkg/provenance/next_test.go
     type: go_test

--- a/provenance/prov-2026-ba04fb6e.yml
+++ b/provenance/prov-2026-ba04fb6e.yml
@@ -1,0 +1,52 @@
+id: prov-2026-ba04fb6e
+title: 'Wire ''linespec provenance next'' command: state gathering, rendering, dual dispatch (Phase 2b)'
+status: draft
+created_at: "2026-06-11"
+author: test@example.com
+intent: |
+  Implements prov-2026-54aaf9cf (Phase 2b). Exposes the pure advice engine as a
+  CLI command.
+
+  - commands.go: NextOptions{Files, Format, ConfigFile} and a Next(opts) method
+    that GATHERS state (records from Loader, staged files from Git.GetStagedFiles,
+    working-tree changes from a new Git helper, intended files from opts) and hands
+    it to Advise. The command is the only I/O boundary; Advise stays pure.
+  - git.go: GetWorkingTreeChanges() -> `git diff --name-only HEAD` (staged +
+    unstaged vs HEAD) so ambient `next` knows what the agent is working on.
+  - formatter.go: FormatNext (human) prints the primary action (reason + ready-to-
+    run command), any governing records as advisory context, and an optional detail
+    block; FormatNextJSON emits the NextAction slice for hook/agent consumption.
+  - cmd/linespec/main_stable.go AND main_beta.go: parseNextOptions (supporting
+    `next`, `next --files ...`, the `--plan` alias for --files, `--json`, `-c`) and
+    a `case "next"` dispatch mirroring the existing context/run-specs pattern.
+constraints:
+  - State gathering lives in the command; Advise receives a fully-populated
+    NextState and remains free of I/O.
+  - The `--plan` flag is an alias for `--files` (intent-aware planning before edits).
+  - The `--json` output renders the same NextAction data the human format renders,
+    so both surfaces stay in lockstep.
+  - The dispatch case must be added to BOTH main_stable.go and main_beta.go.
+affected_scope:
+  - pkg/provenance/commands.go
+  - pkg/provenance/git.go
+  - pkg/provenance/formatter.go
+  - pkg/provenance/next.go
+  - pkg/provenance/next_test.go
+  - cmd/linespec/main_stable.go
+  - cmd/linespec/main_beta.go
+forbidden_scope: []
+type: imprint
+implements: prov-2026-54aaf9cf
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs:
+  - path: pkg/provenance/next_test.go
+    type: go_test
+    run_command: make test # {{path}}
+associated_traces: []
+monitors: []
+tags:
+  - agent-guidance
+  - phase-2

--- a/provenance/prov-2026-cd1405fb.yml
+++ b/provenance/prov-2026-cd1405fb.yml
@@ -1,6 +1,6 @@
 id: prov-2026-cd1405fb
 title: Claude Code provenance plugin hooks (SessionStart/PreToolUse/commit-gate) + active-only per-file lookup + dual install (Phase 5b-5d)
-status: open
+status: implemented
 created_at: "2026-06-12"
 author: test@example.com
 intent: |
@@ -81,7 +81,7 @@ superseded_by: ""
 related:
   - prov-2026-54aaf9cf
   - prov-2026-007c8893
-sealed_at_sha: ""
+sealed_at_sha: 7c9786051ebec2b39448ee63f8bbed465d8058cd
 associated_specs:
   - path: pkg/provenance/scope_index_test.go
     type: go_test

--- a/provenance/prov-2026-cd1405fb.yml
+++ b/provenance/prov-2026-cd1405fb.yml
@@ -1,0 +1,91 @@
+id: prov-2026-cd1405fb
+title: Claude Code provenance plugin hooks (SessionStart/PreToolUse/commit-gate) + active-only per-file lookup + dual install (Phase 5b-5d)
+status: draft
+created_at: "2026-06-12"
+author: test@example.com
+intent: |
+  Completes Phase 5: surface the advice engine (prov-2026-54aaf9cf) inside the agent's
+  loop as a Claude Code plugin, consuming the 5a scope cache (prov-2026-007c8893) so
+  every hook stays fast. The hook scripts are THIN renderers — they shell out to
+  `linespec provenance ...` and format the result; no decision logic is duplicated in
+  the plugin.
+
+  Parts:
+
+  (lookup) Active-only per-file governance lookup. The 5c hook needs "which records
+  govern this file" but must exclude superseded/deprecated records (per the recorded
+  design note) — surfacing a replaced/withdrawn decision in the edit loop is exactly the
+  stale-signal failure mode this whole effort fights. The full `context` command keeps
+  showing everything (history value); this is a NEW, narrow, cache-backed lookup
+  (open + implemented only) the hook calls. It builds on the 5a fast path so it does not
+  pay a full LoadAll.
+
+  (5b) SessionStart hook. Runs the engine once and injects a compact ambient summary of
+  the single correct next action via hookSpecificOutput.additionalContext. The
+  cheapest, highest-value rail — the agent starts every session knowing the next step.
+
+  (5c) PreToolUse hook on Edit and Write. On the first write per file per session, runs
+  the active-only lookup; if any active records govern the file, injects them advisorily
+  (systemMessage / additionalContext, permissionDecision allow — NEVER a block here),
+  ending with the relevant next suggestion. Silent when no active record governs the
+  file (the common case). Dedup per file per session so it speaks at most once per file.
+
+  (5d) Commit-boundary gate. PostToolUse on Bash scoped to `git commit` (matcher Bash +
+  an `if: "Bash(git commit *)"` rule). Quiet on a clean commit. When the commit FAILED
+  on a provenance violation (the git commit-msg/pre-commit hook rejected it), it hands
+  the agent the engine's exact remediation as feedback rather than a bare door. The git
+  hook remains the actual gate; this surfaces the fix inside Claude's loop.
+
+  (command) Slash command. Bundle a commands/provenance-next.md slash command in the
+  plugin that runs `linespec provenance next`, so a user can ask for the engine's
+  guidance explicitly (on demand), not only through the hooks. Renders the same engine.
+
+  (install) Dual installation. (1) A `linespec provenance install-plugin` command
+  mirroring the existing install-skills/scripts/install-skill pattern, copying the
+  plugin into a target Claude Code config. (3) A marketplace-style
+  .claude-plugin/marketplace.json + .claude-plugin/plugin.json so users can also
+  `claude plugin install`. Hook scripts reference bundled paths via
+  ${CLAUDE_PLUGIN_ROOT} and call `linespec` from PATH.
+constraints:
+  - Every hook renders from the engine via `linespec provenance ...` (next/the active-only
+    lookup); the plugin holds NO copy of the advice/governance decision logic.
+  - The active-only per-file lookup returns only `open` + `implemented` records (excludes
+    superseded/deprecated), and is cache-backed (5a) so it never pays a full LoadAll on a
+    cache hit. A unit test asserts the status filtering.
+  - SessionStart (5b) and PreToolUse (5c) are advisory ONLY — they never block a tool.
+    5c is silent when no active record governs the file, and speaks at most once per file
+    per session (deduped).
+  - The only place that surfaces a block-style message is the commit gate (5d), and only
+    when a real commit-time provenance violation occurred; it always includes the engine's
+    exact remediation command.
+  - Hooks must stay fast (well under the budget) — no full record reload on the hot path
+    (use the 5a cache), no expensive path (no completion teeth, no embedding/index build)
+    invoked from any hook. Tool/path matching is done by hook matchers, not in-script.
+  - Over-gating is the footgun that caused the original incident — after a few consecutive
+    denials an agent escalates to the human and bails. Hooks err toward quiet/advisory.
+  - Installation must not clobber unrelated user Claude Code config; it adds the plugin
+    and its hooks only. Both install paths (command and marketplace) yield the same hooks.
+  - make test must pass; the new lookup and any new Go wiring are covered by tests.
+affected_scope:
+  - plugins/provenance/**
+  - scripts/install-plugin
+  - pkg/provenance/scope_index.go
+  - pkg/provenance/scope_index_test.go
+  - pkg/provenance/commands.go
+  - cmd/linespec/main_stable.go
+  - cmd/linespec/main_beta.go
+forbidden_scope: []
+type: blueprint
+supersedes: ""
+superseded_by: ""
+related:
+  - prov-2026-54aaf9cf
+  - prov-2026-007c8893
+sealed_at_sha: ""
+associated_specs: []
+associated_traces: []
+monitors: []
+tags:
+  - agent-guidance
+  - phase-5
+  - claude-code-plugin

--- a/provenance/prov-2026-cd1405fb.yml
+++ b/provenance/prov-2026-cd1405fb.yml
@@ -1,6 +1,6 @@
 id: prov-2026-cd1405fb
 title: Claude Code provenance plugin hooks (SessionStart/PreToolUse/commit-gate) + active-only per-file lookup + dual install (Phase 5b-5d)
-status: draft
+status: open
 created_at: "2026-06-12"
 author: test@example.com
 intent: |
@@ -82,7 +82,10 @@ related:
   - prov-2026-54aaf9cf
   - prov-2026-007c8893
 sealed_at_sha: ""
-associated_specs: []
+associated_specs:
+  - path: pkg/provenance/scope_index_test.go
+    type: go_test
+    run_command: make test # {{path}}
 associated_traces: []
 monitors: []
 tags:

--- a/provenance/prov-2026-ee9f957d.yml
+++ b/provenance/prov-2026-ee9f957d.yml
@@ -1,6 +1,6 @@
 id: prov-2026-ee9f957d
 title: 'Plugin assets: plugin.json/marketplace.json, hooks.json, SessionStart/PreToolUse/commit hook scripts, provenance-next slash command (5b-5d)'
-status: draft
+status: open
 created_at: "2026-06-12"
 author: test@example.com
 intent: |

--- a/provenance/prov-2026-ee9f957d.yml
+++ b/provenance/prov-2026-ee9f957d.yml
@@ -1,6 +1,6 @@
 id: prov-2026-ee9f957d
 title: 'Plugin assets: plugin.json/marketplace.json, hooks.json, SessionStart/PreToolUse/commit hook scripts, provenance-next slash command (5b-5d)'
-status: open
+status: implemented
 created_at: "2026-06-12"
 author: test@example.com
 intent: |
@@ -45,7 +45,7 @@ implements: prov-2026-cd1405fb
 supersedes: ""
 superseded_by: ""
 related: []
-sealed_at_sha: ""
+sealed_at_sha: e1419af4dc7dc2b2b52551270a78de6a00ebfbb8
 associated_specs:
   - path: plugins/provenance/.claude-plugin/plugin.json
     run_command: test -f {{path}}

--- a/provenance/prov-2026-ee9f957d.yml
+++ b/provenance/prov-2026-ee9f957d.yml
@@ -1,0 +1,56 @@
+id: prov-2026-ee9f957d
+title: 'Plugin assets: plugin.json/marketplace.json, hooks.json, SessionStart/PreToolUse/commit hook scripts, provenance-next slash command (5b-5d)'
+status: draft
+created_at: "2026-06-12"
+author: test@example.com
+intent: |
+  Implements prov-2026-cd1405fb. The Claude Code plugin files under
+  plugins/provenance/. All hook scripts are thin renderers that shell out to
+  `linespec provenance ...` and emit hook JSON.
+
+  - .claude-plugin/plugin.json: plugin manifest (name, description, version, points
+    hooks at hooks/hooks.json).
+  - .claude-plugin/marketplace.json: single-plugin marketplace so users can
+    `claude plugin marketplace add` + `claude plugin install`.
+  - hooks/hooks.json: SessionStart (matcher startup|resume), PreToolUse (matcher
+    Edit|Write), PostToolUse (matcher Bash) — each pointing at a ${CLAUDE_PLUGIN_ROOT}
+    script with a short timeout.
+  - hooks/session-start.sh (5b): runs `linespec provenance next --json`, injects a
+    compact additionalContext summary. Silent if linespec/jq missing or not a repo.
+  - hooks/pre-edit.sh (5c): on first Edit/Write per file per session (deduped via a
+    per-session marker under the data dir), runs `govern --files <path> --json`;
+    injects governing records + the next suggestion as additionalContext only when at
+    least one ACTIVE record governs the file. Never blocks (permissionDecision allow).
+  - hooks/post-commit.sh (5d): scoped IN-SCRIPT to `git commit` (the only content-level
+    filter available — tool matchers cannot see command text). Quiet unless the commit
+    FAILED on a provenance violation, in which case it surfaces `next`'s remediation as
+    advisory feedback. The git hook stays the real gate.
+  - commands/provenance-next.md: a /provenance-next slash command that runs
+    `linespec provenance next`.
+constraints:
+  - Hook scripts contain no advice logic — they only call `linespec` and format its
+    output into hook JSON.
+  - Scripts are silent/no-op when linespec is absent, jq is absent, the dir is not a
+    provenance repo, or there is nothing to say (degrade gracefully, never error the
+    tool call).
+  - 5c dedups per file per session and never blocks; 5d only surfaces feedback on a
+    real failed-commit provenance violation.
+  - Hook scripts use ${CLAUDE_PLUGIN_ROOT} for bundled paths and call `linespec` from
+    PATH; per-session state lives under the data dir, not the (immutable) plugin root.
+affected_scope:
+  - plugins/provenance/**
+forbidden_scope: []
+type: imprint
+implements: prov-2026-cd1405fb
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs:
+  - path: plugins/provenance/.claude-plugin/plugin.json
+    run_command: test -f {{path}}
+associated_traces: []
+monitors: []
+tags:
+  - phase-5
+  - claude-code-plugin

--- a/provenance/prov-2026-f25de965.yml
+++ b/provenance/prov-2026-f25de965.yml
@@ -1,6 +1,6 @@
 id: prov-2026-f25de965
 title: 'Teeth-config implementation: normalize invalid->block, remote-skip in selectors, warn/off in Complete'
-status: draft
+status: open
 created_at: "2026-06-11"
 author: test@example.com
 intent: |

--- a/provenance/prov-2026-f25de965.yml
+++ b/provenance/prov-2026-f25de965.yml
@@ -1,0 +1,52 @@
+id: prov-2026-f25de965
+title: 'Teeth-config implementation: normalize invalid->block, remote-skip in selectors, warn/off in Complete'
+status: draft
+created_at: "2026-06-11"
+author: test@example.com
+intent: |
+  Implements prov-2026-21e9f419. Records the concrete implementation decisions:
+
+  - Mode constants live in the provenance package (OverlapSpecsBlock/Warn/Off =
+    "block"/"warn"/"off"). A normalizeOverlapMode helper maps "" -> block (backward
+    compatible default) and any unrecognized value -> block, printing a one-line
+    stderr notice so an invalid setting is never silently treated as off.
+  - Remote-skip is added directly to the two selector functions
+    (overlappingSealedRecords, declaredOverlapSealedRecords) by extending their
+    existing skip guard with `|| c.isRemoteRecord(r)`. Putting it in the selectors
+    (not the Complete loop) means both the completion teeth and the open-time
+    heads-up exclude remote records with one change each.
+  - In Complete, the teeth block reads the normalized mode. off -> the
+    completionOverlapSelector call is skipped entirely (no selection, no run, no
+    FYI for touched-with-specs; the no-spec FYI is also skipped). block -> unchanged
+    (rollback on failure). warn -> specs still run for streamed output, but a
+    failure is collected and rendered as a non-blocking FYI instead of triggering
+    rollback; completion proceeds.
+  - The master switch run_associated_specs_on_complete is unchanged and still gates
+    whether any specs run; the new mode only refines the overlap-teeth severity when
+    the master switch is on.
+constraints:
+  - Invalid/empty mode normalizes to block; never silently off.
+  - off skips selection so it costs nothing (no git history walk for overlap).
+  - warn must not roll back; it completes and prints a non-blocking FYI.
+affected_scope:
+  - pkg/config/types.go
+  - pkg/provenance/commands.go
+  - pkg/provenance/overlap_specs_test.go
+  - cmd/linespec/main_stable.go
+  - cmd/linespec/main_beta.go
+forbidden_scope: []
+type: imprint
+implements: prov-2026-21e9f419
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs:
+  - path: pkg/provenance/overlap_specs_test.go
+    type: go_test
+    run_command: make test # {{path}}
+associated_traces: []
+monitors: []
+tags:
+  - governance-overlap
+  - config

--- a/provenance/prov-2026-f25de965.yml
+++ b/provenance/prov-2026-f25de965.yml
@@ -1,6 +1,6 @@
 id: prov-2026-f25de965
 title: 'Teeth-config implementation: normalize invalid->block, remote-skip in selectors, warn/off in Complete'
-status: open
+status: implemented
 created_at: "2026-06-11"
 author: test@example.com
 intent: |
@@ -40,7 +40,7 @@ implements: prov-2026-21e9f419
 supersedes: ""
 superseded_by: ""
 related: []
-sealed_at_sha: ""
+sealed_at_sha: c6cea75b44cf328b9ea45a75fe00e9cd7ace1080
 associated_specs:
   - path: pkg/provenance/overlap_specs_test.go
     type: go_test

--- a/scripts/install-plugin
+++ b/scripts/install-plugin
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# install-plugin — copies the LineSpec provenance Claude Code plugin into a target
+# Claude Code config (mirrors scripts/install-skill). The `linespec provenance
+# install-plugin` command does the same from the embedded copy; this script is the
+# in-repo / no-binary alternative. Implemented as part of prov-2026-cd1405fb.
+#
+# Usage:
+#   install-plugin <target-path>
+#
+# Arguments:
+#   target-path   Directory where the plugin folder will be created
+#                 (e.g. .claude/plugins). Created if it doesn't exist.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LINESPEC_ROOT="$(dirname "$SCRIPT_DIR")"
+SOURCE_DIR="$LINESPEC_ROOT/plugins/provenance"
+
+usage() {
+  echo "Usage: install-plugin <target-path>" >&2
+  echo "" >&2
+  echo "  target-path   Directory where the plugin folder will be created" >&2
+  echo "                (e.g. .claude/plugins)" >&2
+  exit 1
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+fi
+
+TARGET_PATH="$1"
+DEST_DIR="$TARGET_PATH/linespec-provenance"
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+  echo "error: plugin source not found at $SOURCE_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$TARGET_PATH"
+rm -rf "$DEST_DIR"
+cp -r "$SOURCE_DIR" "$DEST_DIR"
+# embed.FS drops modes for the Go path; here cp preserves them, but re-assert anyway.
+chmod +x "$DEST_DIR"/hooks/*.sh 2>/dev/null || true
+# The Go source file is not part of the installed plugin.
+rm -f "$DEST_DIR/embed.go"
+
+echo "Installed plugin 'linespec-provenance' to $DEST_DIR"
+echo ""
+echo "Enable it in your Claude Code settings, or install via the marketplace:"
+echo "  claude plugin marketplace add $LINESPEC_ROOT/plugins/provenance"
+echo "  claude plugin install linespec-provenance@linespec"


### PR DESCRIPTION
## Agent-guidance for provenance: computed `next` engine + Claude Code plugin

Replaces error-driven navigation of provenance enforcement with **computed, state-aware guidance**, rendered from a single engine across every surface. Origin: an advanced model spent ~$400 misreading a non-blocking supersede warning as a hard block and concluding it had to supersede ~11 sealed records.

### What's in here (by phase)

- **Phase 1 — reworded guidance** *(already on branch base)*: the stale-scope warning, commit-violation hint, and locked-scope error no longer imply that touching a governed file requires superseding.
- **Phase 2 — the `next` advice engine (keystone)**: one pure `Advise(NextState)` function maps state → the correct next action (create / open / add spec / commit / complete) with record IDs filled in. Exposed as `linespec provenance next` (ambient / `--files` / `--plan` / `--json`); the reworded CLI hints now render from this same engine, so "skill says X but CLI prints Y" drift is structurally impossible.
- **Phase 3/4 — verified** (governed by `bc57fbdc`): the governance-overlap signal lives on lifecycle transitions, and completion runs the specs of sealed records a change actually touches.
- **Teeth config** — `overlap_specs_on_complete: block|warn|off` (default `block`) + skip remote records. Surfaced and fixed a real flaky-rollback blast radius: completing broadly-scoped files pulled in the whole Docker integration matrix and could roll back an unrelated, correct completion. This repo now runs `warn`.
- **Phase 5a — scope cache** (`.linespec/scope-index.json`): compact, stat-fingerprinted, self-healing cache making `next`/`govern` ~12× faster (449ms → 38ms) — fast enough for a per-edit hook, with fallback to the authoritative load on any doubt.
- **Phase 5b–5d — Claude Code plugin** (`plugins/provenance/`): SessionStart next-action rail, advisory per-edit governance (PreToolUse), commit-rejection remediation (PostToolUse), a `/provenance-next` slash command, plus a new `govern` command (active-only per-file lookup, excludes superseded/deprecated). Installable via `linespec provenance install-plugin` (embedded) **and** the Claude Code marketplace.
- **Docs** — every reference doc and the doc site (`PROVENANCE_RECORDS.md`, `PROVENANCE_RECORD_SCHEMA.md`, `README.md`, `CLAUDE.md`, `LINESPEC.md`, `CHANGELOG.md`, `docs/*.html`, `docs/llms*.txt`) document the new commands, config, plugin, and cache.

### Verification

- Full `make test` green; `make quality` (staticcheck + deadcode) passes.
- New behavior covered by unit tests: engine state-branches, cached-vs-uncached equivalence, fingerprint invalidation/fallback, teeth modes (block/warn/off), remote exclusion, active-only lookup, plugin install.
- All three hooks smoke-tested end-to-end; plugin JSON valid; hook scripts pass `bash -n`.

### Process

Built under 14 provenance records (every change tagged, every blueprint opened/sealed with proof). No VERSION bump / no release — a single `[Unreleased]` CHANGELOG entry (release happens after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
