### PR TITLE
Blueprint: Add provenance configuration to exclude file or directory paths from rules

### DIFF
--- a/pkg/config/exclude_paths_test.go
+++ b/pkg/config/exclude_paths_test.go
@@ -1,0 +1,1 @@
+package config

--- a/pkg/provenance/exclude_paths_test.go
+++ b/pkg/provenance/exclude_paths_test.go
@@ -1,0 +1,1 @@
+package provenance

--- a/provenance/prov-2026-1b5fa2c2.yml
+++ b/provenance/prov-2026-1b5fa2c2.yml
@@ -1,0 +1,44 @@
+id: prov-2026-1b5fa2c2
+title: Add exclude_paths config to exempt files from provenance rules
+status: draft
+created_at: "2026-06-22"
+author: calebcowen@gmail.com
+implements: prov-2026-bb380f4b
+intent: >
+  Engineers often maintain generated files, documentation, migration scripts, or
+  tooling configs that should not require provenance governance. This adds an
+  exclude_paths list to the provenance section of .linespec.yml that accepts
+  glob patterns, full file paths, directory prefixes, and regex patterns. Any
+  file matching at least one entry is fully exempt: the linter skips it, the
+  commit checker skips both scope-enforcement and the commit-tag requirement,
+  and the context command surfaces the exemption status explicitly rather than
+  silently omitting it.
+constraints:
+  - The .linespec.yml provenance section must accept an exclude_paths field as a list of strings; each entry may be a full file path, a glob, a directory path (matched as prefix), or a regex (recognized by leading/trailing slash, e.g. /.*_gen\.go$/).
+  - Matching must be evaluated before any other provenance rule — an excluded file cannot trigger a scope violation, a missing-commit-tag violation, or any linter warning.
+  - The context command must report that a file is exempt from provenance rules when the queried file matches exclude_paths, in addition to any historical record context.
+  - The git hooks (pre-commit scope check and commit-msg tag check) must both skip excluded files entirely.
+  - Draft and open records are not affected by this exemption mechanism — exclude_paths is a path-level bypass, not a record-level bypass.
+  - The ProvenanceConfig struct in both pkg/config/types.go and pkg/provenance/commands.go must expose ExcludePaths []string so the field flows from YAML parsing through to all enforcement sites.
+  - All new behavior must be covered by unit tests in the provenance and config packages.
+affected_scope:
+  - pkg/config/types.go
+  - pkg/provenance/commands.go
+  - pkg/provenance/linter.go
+  - pkg/provenance/git.go
+forbidden_scope: []
+type: blueprint
+supersedes: ""
+superseded_by: ""
+related: []
+sealed_at_sha: ""
+associated_specs:
+  - path: pkg/provenance/exclude_paths_test.go
+    type: go_test
+    run_command: make test
+  - path: pkg/config/exclude_paths_test.go
+    type: go_test
+    run_command: make test
+associated_traces: []
+monitors: []
+tags: []


### PR DESCRIPTION
Draft Blueprint `prov-2026-1b5fa2c2` implementing brief `prov-2026-bb380f4b`.

Validated with `linespec provenance open` (then reverted to draft). Generated by the LineSpec orchestrator (Job A) — review and open from the UI to trigger implementation.