### PR TITLE
Implement: reconcile locks LineSpec's own tracked .linespec/ state files (embeddings.bin, hash_manifest.json)

### DIFF
--- a/pkg/provenance/fswrite.go
+++ b/pkg/provenance/fswrite.go
@@ -37,23 +37,25 @@ const (
 	dirPermUnlockAdd os.FileMode = 0o300
 )
 
-// managedStatePaths returns LineSpec's own machine-regenerated state files
-// under .linespec/ that are sometimes git-tracked (e.g. embeddings.bin,
-// hash_manifest.json) but must never be locked by the write-permission
-// projection: they are not human-authored source the provenance-before-code
-// invariant is meant to gate, and reconcile locking them breaks the very
-// tools (embeddings index, hash manifest) that regenerate them (prov-2026-26efc162).
+// managedStatePaths returns the directory of LineSpec's own machine-regenerated
+// state under .linespec/ (e.g. embeddings.bin, hash_manifest.json, and any
+// future managed file placed there) that must never be locked by the
+// write-permission projection: it is not human-authored source the
+// provenance-before-code invariant is meant to gate, and reconcile locking it
+// breaks the very tools (embeddings index, hash manifest) that regenerate it
+// (prov-2026-26efc162). The whole directory is exempted, rather than naming
+// individual files, so newly added managed state never needs a matching
+// AlwaysWritablePaths update.
 func managedStatePaths() []string {
 	return []string{
-		".linespec/embeddings.bin",
-		".linespec/hash_manifest.json",
+		".linespec",
 	}
 }
 
 // AlwaysWritablePaths returns the derived always-writable pattern set: the
 // existing provenance.exclude_paths whitelist plus the authoring coop — the
 // configured provenance directory, .linespec.yml, LineSpec's own managed
-// .linespec/ state files (managedStatePaths), and every associated_spec path
+// .linespec/ state directory (managedStatePaths), and every associated_spec path
 // across all loaded records (regardless of status), so the
 // Brief-to-Blueprint-to-Imprint authoring chain can never block its own
 // creation. This set is derived, never separately hand-maintained. repoRoot

--- a/pkg/provenance/fswrite.go
+++ b/pkg/provenance/fswrite.go
@@ -37,10 +37,24 @@ const (
 	dirPermUnlockAdd os.FileMode = 0o300
 )
 
+// managedStatePaths returns LineSpec's own machine-regenerated state files
+// under .linespec/ that are sometimes git-tracked (e.g. embeddings.bin,
+// hash_manifest.json) but must never be locked by the write-permission
+// projection: they are not human-authored source the provenance-before-code
+// invariant is meant to gate, and reconcile locking them breaks the very
+// tools (embeddings index, hash manifest) that regenerate them (prov-2026-26efc162).
+func managedStatePaths() []string {
+	return []string{
+		".linespec/embeddings.bin",
+		".linespec/hash_manifest.json",
+	}
+}
+
 // AlwaysWritablePaths returns the derived always-writable pattern set: the
 // existing provenance.exclude_paths whitelist plus the authoring coop — the
-// configured provenance directory, .linespec.yml, and every associated_spec
-// path across all loaded records (regardless of status), so the
+// configured provenance directory, .linespec.yml, LineSpec's own managed
+// .linespec/ state files (managedStatePaths), and every associated_spec path
+// across all loaded records (regardless of status), so the
 // Brief-to-Blueprint-to-Imprint authoring chain can never block its own
 // creation. This set is derived, never separately hand-maintained. repoRoot
 // normalizes an absolute config.Dir to repo-relative, since every path this
@@ -60,6 +74,7 @@ func AlwaysWritablePaths(config *ProvenanceConfig, records []*Record, repoRoot s
 		}
 	}
 	out = append(out, dir, ".linespec.yml")
+	out = append(out, managedStatePaths()...)
 
 	seen := map[string]bool{}
 	for _, r := range records {

--- a/pkg/provenance/fswrite_test.go
+++ b/pkg/provenance/fswrite_test.go
@@ -389,13 +389,12 @@ func TestReconcile_UnlocksParentDirOfDeclaredNotYetExistingPath(t *testing.T) {
 // TestAlwaysWritablePaths_IncludesManagedLinespecStateFiles reproduces the bug:
 // LineSpec's own regenerated state files under .linespec/ (embeddings.bin,
 // hash_manifest.json) were not part of the always-writable "authoring coop",
-// so reconcile locked them whenever they happened to be git-tracked.
+// so reconcile locked them whenever they happened to be git-tracked. The whole
+// .linespec/ directory is exempted rather than individual filenames, so any
+// file under it — including ones not yet named here — stays writable.
 func TestAlwaysWritablePaths_IncludesManagedLinespecStateFiles(t *testing.T) {
 	always := AlwaysWritablePaths(&ProvenanceConfig{Dir: "provenance"}, nil, "")
-	for _, want := range []string{".linespec/embeddings.bin", ".linespec/hash_manifest.json"} {
-		if !slices.Contains(always, want) {
-			t.Errorf("AlwaysWritablePaths missing managed state path %q, got %v", want, always)
-		}
+	for _, want := range []string{".linespec/embeddings.bin", ".linespec/hash_manifest.json", ".linespec/anything_else.json"} {
 		if !IsAlwaysWritable(want, always) {
 			t.Errorf("IsAlwaysWritable(%q) = false, want true (managed LineSpec state must never be locked)", want)
 		}

--- a/pkg/provenance/fswrite_test.go
+++ b/pkg/provenance/fswrite_test.go
@@ -1,9 +1,11 @@
 package provenance
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -379,5 +381,108 @@ func TestReconcile_UnlocksParentDirOfDeclaredNotYetExistingPath(t *testing.T) {
 	info, _ := os.Stat(filepath.Join(repo, "pkg"))
 	if info.Mode().Perm()&0o200 == 0 {
 		t.Errorf("expected pkg/ unlocked so pkg/new_file.go could be created, mode = %o", info.Mode().Perm())
+	}
+}
+
+// --- Managed .linespec/ state (prov-2026-26efc162) --------------------------
+
+// TestAlwaysWritablePaths_IncludesManagedLinespecStateFiles reproduces the bug:
+// LineSpec's own regenerated state files under .linespec/ (embeddings.bin,
+// hash_manifest.json) were not part of the always-writable "authoring coop",
+// so reconcile locked them whenever they happened to be git-tracked.
+func TestAlwaysWritablePaths_IncludesManagedLinespecStateFiles(t *testing.T) {
+	always := AlwaysWritablePaths(&ProvenanceConfig{Dir: "provenance"}, nil, "")
+	for _, want := range []string{".linespec/embeddings.bin", ".linespec/hash_manifest.json"} {
+		if !slices.Contains(always, want) {
+			t.Errorf("AlwaysWritablePaths missing managed state path %q, got %v", want, always)
+		}
+		if !IsAlwaysWritable(want, always) {
+			t.Errorf("IsAlwaysWritable(%q) = false, want true (managed LineSpec state must never be locked)", want)
+		}
+	}
+}
+
+// TestReconcile_NeverLocksTrackedLinespecStateFiles reproduces the reported
+// failure end to end: a repo that git-tracks .linespec/embeddings.bin and
+// .linespec/hash_manifest.json (as this repo does) must come out of reconcile
+// with both still writable, even though no open record's affected_scope covers
+// them and they are not in provenance.exclude_paths. Before the fix these were
+// locked read-only, and the next `provenance index` / `complete` failed with
+// "permission denied" trying to regenerate them.
+func TestReconcile_NeverLocksTrackedLinespecStateFiles(t *testing.T) {
+	repo := t.TempDir()
+	linespecDir := filepath.Join(repo, ".linespec")
+	if err := os.MkdirAll(linespecDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	embeddingsPath := filepath.Join(linespecDir, "embeddings.bin")
+	manifestPath := filepath.Join(linespecDir, "hash_manifest.json")
+	writePerm(t, embeddingsPath, 0o644)
+	writePerm(t, manifestPath, 0o644)
+
+	// An unrelated open record whose scope does not cover .linespec/ at all —
+	// mirrors the reported repro where these files fall outside every open
+	// record's affected_scope.
+	records := []*Record{
+		{ID: "prov-2026-0001", Status: StatusOpen, AffectedScope: []string{"pkg/unrelated.go"}},
+	}
+	config := &ProvenanceConfig{Dir: "provenance"}
+
+	result, err := Reconcile(repo, []string{".linespec/embeddings.bin", ".linespec/hash_manifest.json"}, records, config)
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if !isWritableOnDisk(t, embeddingsPath) {
+		t.Errorf(".linespec/embeddings.bin must stay writable — it is LineSpec's own regenerated state, not governed source")
+	}
+	if !isWritableOnDisk(t, manifestPath) {
+		t.Errorf(".linespec/hash_manifest.json must stay writable — it is LineSpec's own regenerated state, not governed source")
+	}
+	if slices.Contains(result.Locked, ".linespec/embeddings.bin") || slices.Contains(result.Locked, ".linespec/hash_manifest.json") {
+		t.Errorf("reconcile must never report managed .linespec/ state as locked, got Locked=%v", result.Locked)
+	}
+}
+
+// TestRefreshScopeIndexCache_WarnsOnSaveFailureInsteadOfSwallowingIt covers the
+// secondary half of prov-2026-26efc162: when the scope-index cache write fails
+// (e.g. its directory got locked, or is otherwise unwritable), the failure must
+// be visible on stderr rather than silently discarded, which previously left a
+// permanently stale cache with no signal to the user (refreshScopeIndexCache in
+// pkg/provenance/scope_index.go).
+func TestRefreshScopeIndexCache_WarnsOnSaveFailureInsteadOfSwallowingIt(t *testing.T) {
+	repo := t.TempDir()
+	provDir := filepath.Join(repo, "provenance")
+	if err := os.MkdirAll(provDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(provDir, "prov-2026-00000001.yml"), []byte("id: x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make .linespec/ itself unwritable so save() fails trying to MkdirAll into it.
+	linespecDir := filepath.Join(repo, ".linespec")
+	if err := os.MkdirAll(linespecDir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(linespecDir, 0o755) })
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	refreshScopeIndexCache(repo, []string{provDir}, []*Record{{ID: "prov-2026-00000001", Status: StatusDraft}})
+
+	w.Close()
+	os.Stderr = origStderr
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "Warning") {
+		t.Errorf("expected a warning on stderr when the scope index cache fails to save, got %q", buf.String())
 	}
 }

--- a/pkg/provenance/scope_index.go
+++ b/pkg/provenance/scope_index.go
@@ -169,8 +169,10 @@ func loadFreshScopeIndex(repoRoot string, dirs []string) (*ScopeIndex, bool) {
 
 // refreshScopeIndexCache rewrites the scope cache from the freshly-loaded records,
 // but only when the on-disk cache is missing or stale — so the common already-fresh
-// case costs one stat-walk and no write. Best-effort: the cache is advisory, so all
-// errors are ignored.
+// case costs one stat-walk and no write. Best-effort: the cache is advisory, so a
+// write failure never blocks the caller — but it is surfaced as a warning rather
+// than swallowed, so a permanently stale cache (e.g. reconcile having locked the
+// cache file itself, prov-2026-26efc162) leaves a visible signal instead of none.
 func refreshScopeIndexCache(repoRoot string, dirs []string, records []*Record) {
 	if repoRoot == "" {
 		return
@@ -183,7 +185,9 @@ func refreshScopeIndexCache(repoRoot string, dirs []string, records []*Record) {
 	if existing, err := loadScopeIndex(path); err == nil && existing.Fingerprint == fp {
 		return // already fresh
 	}
-	_ = buildScopeIndex(records, fp).save(path)
+	if err := buildScopeIndex(records, fp).save(path); err != nil {
+		fmtWarnf("failed to refresh scope index cache at %s: %v", path, err)
+	}
 }
 
 // loaderDirs returns the directories LoadAll reads: the (absolute) local provenance

--- a/provenance/prov-2026-26efc162.yml
+++ b/provenance/prov-2026-26efc162.yml
@@ -54,6 +54,7 @@ constraints:
     visible instead of silently stale. Secondary to the always-writable fix.
 affected_scope:
   - pkg/provenance/fswrite.go
+  - pkg/provenance/fswrite_test.go
   - pkg/provenance/scope_index.go
 forbidden_scope: []
 type: bug


### PR DESCRIPTION
Implementation of `prov-2026-26efc162`.

Generated by the LineSpec orchestrator (Job B).