### PR TITLE
Update provenance record prov-2026-26efc162

### DIFF
--- a/provenance/prov-2026-26efc162.yml
+++ b/provenance/prov-2026-26efc162.yml
@@ -1,9 +1,9 @@
 id: prov-2026-26efc162
 title: reconcile locks LineSpec's own tracked .linespec/ state files (embeddings.bin, hash_manifest.json)
-status: open
-created_at: "2026-07-14"
+status: implemented
+created_at: '2026-07-14'
 author: calebcowen@gmail.com
-intent: |
+intent: |-
   The fswrite write-permission projection (blueprint prov-2026-8d2f5f2a) locks every
   git-tracked file that is not covered by an open, allowlist-mode record's affected_scope,
   and holds writable only the "authoring coop" returned by AlwaysWritablePaths
@@ -35,36 +35,28 @@ intent: |
   .linespec/ state from the write-permission projection, the same way the provenance dir and
   .linespec.yml are already always-writable.
 constraints:
-  - |
-    Add LineSpec's managed .linespec/ state files to the always-writable set in
-    AlwaysWritablePaths (pkg/provenance/fswrite.go) — at minimum .linespec/embeddings.bin and
-    .linespec/hash_manifest.json, preferably the managed-state paths as a group — mirroring the
-    existing always-writable treatment of the provenance dir and .linespec.yml, so reconcile
-    never locks state LineSpec itself regenerates.
-  - |
-    After the fix, running `reconcile` (directly, or via `next`) in a repo that tracks
-    .linespec/embeddings.bin and/or .linespec/hash_manifest.json leaves both writable, and a
-    subsequent `provenance index` succeeds instead of failing with "permission denied".
-  - |
-    Projection semantics for genuine source are unchanged: out-of-scope tracked source files
-    still lock, and files covered by an open allowlist record's affected_scope stay writable.
-  - |
-    Consider surfacing rather than swallowing scope-index cache write failures
-    (refreshScopeIndexCache in pkg/provenance/scope_index.go) so an unwritable cache is
-    visible instead of silently stale. Secondary to the always-writable fix.
+  - Add LineSpec's managed .linespec/ state files to the always-writable set in
+  - AlwaysWritablePaths (pkg/provenance/fswrite.go) — at minimum .linespec/embeddings.bin and
+  - .linespec/hash_manifest.json, preferably the managed-state paths as a group — mirroring the
+  - existing always-writable treatment of the provenance dir and .linespec.yml, so reconcile
+  - never locks state LineSpec itself regenerates.
+  - After the fix, running `reconcile` (directly, or via `next`) in a repo that tracks
+  - .linespec/embeddings.bin and/or .linespec/hash_manifest.json leaves both writable, and a
+  - subsequent `provenance index` succeeds instead of failing with "permission denied".
+  - 'Projection semantics for genuine source are unchanged: out-of-scope tracked source files'
+  - still lock, and files covered by an open allowlist record's affected_scope stay writable.
+  - Consider surfacing rather than swallowing scope-index cache write failures
+  - (refreshScopeIndexCache in pkg/provenance/scope_index.go) so an unwritable cache is
+  - visible instead of silently stale. Secondary to the always-writable fix.
 affected_scope:
   - pkg/provenance/fswrite.go
   - pkg/provenance/scope_index.go
-forbidden_scope: []
 type: bug
 extends: prov-2026-8d2f5f2a
-supersedes: ""
-superseded_by: ""
-related: []
-sealed_at_sha: ""
+superseded_by: ''
+sealed_at_sha: ''
 associated_specs:
   - path: pkg/provenance/fswrite_test.go
-    type: go_test
     run_command: make test
 associated_traces: []
 monitors: []


### PR DESCRIPTION
Automated edit via linespec-provenance-ui.

Changes: status: open → implemented

Record: `prov-2026-26efc162`