### PR TITLE
Fix run_command double-path in prov-2026-a0bac0d9 (unblocks Job B verify gate)

### DIFF
--- a/provenance/prov-2026-a0bac0d9.yml
+++ b/provenance/prov-2026-a0bac0d9.yml
@@ -29,7 +29,7 @@ superseded_by: ''
 sealed_at_sha: ''
 associated_specs:
   - path: examples/asynq-worker/linespecs/process_report_job.linespec
-    run_command: linespec test examples/asynq-worker/linespecs/process_report_job.linespec
+    run_command: linespec test {{path}}
   - path: pkg/config/database_port_default_test.go
     run_command: go test ./pkg/config/... -run TestDatabasePortDefaultsWithExplicitImage -v
   - path: pkg/runner/network_cleanup_test.go


### PR DESCRIPTION
`linespec` appends the spec path to `run_command` **unless** the command contains `{{path}}` ([`commands.go:2109`](https://github.com/livecodelife/linespec/blob/main/pkg/provenance/commands.go#L2109)). The first spec on `prov-2026-a0bac0d9` already named its own path, so it ran as:

```
linespec test <path> <path>   ->   Error: accepts 1 arg(s), received 2
```

### Impact
This failed the orchestrator's **Job B verify gate deterministically** — independent of the implementation. Job B therefore aborted without pushing, the record stayed `open` with no impl branch, and the next tick started the whole implementation again:

```
21:30:53  Job B: implementing prov-2026-a0bac0d9
22:11:40  claude done — turns=199 cost=$16.85 dur=40m45s
22:11:43  verify gate failed: accepts 1 arg(s), received 2 — abort, no PR
22:11:49  Job B: implementing prov-2026-a0bac0d9   <- restarted from scratch
```

~40 minutes and ~$17 discarded per cycle, indefinitely. The author loop is currently stopped to halt it.

### Fix
Use the `{{path}}` placeholder so the path is substituted rather than appended. Verified locally — the spec now runs and passes:

```
· examples/asynq-worker/linespecs/process_report_job.linespec
  linespec test examples/asynq-worker/linespecs/process_report_job.linespec
  ✅ Passed!  ✓ passed
```

The other two specs still fail as "pending implementation", which is correct — the gate *should* fail until Job B implements them.

### Note
`{{path}}`-less `run_command`s that embed their own path exist on 5 other records. They don't error today because their commands tolerate an extra argument (e.g. shell scripts), but they are the same latent shape.