### PR TITLE
Update provenance record prov-2026-3687be46

### DIFF
--- a/provenance/prov-2026-3687be46.yml
+++ b/provenance/prov-2026-3687be46.yml
@@ -1,7 +1,7 @@
 id: prov-2026-3687be46
 title: .linespec/hash_manifest.json conflicts on every rebase, and no merge strategy resolves it safely
-status: draft
-created_at: "2026-08-11"
+status: open
+created_at: '2026-08-11'
 author: 305597777+agent-loops-boxd[bot]@users.noreply.github.com
 intent: 'Fix .linespec/hash_manifest.json (pkg/provenance/hasher.go) reported against GitHub issue #163: independent branches that each seal one record touch the same sorted `records` map plus the two aggregate hashes (`full_graph_hash`, `active_subset_hash`), so the file text-conflicts on essentially every rebase in a repo with concurrent provenance PRs, and no client-side merge strategy resolves it safely. `merge=union` produces invalid JSON (duplicate keys, broken sort). A merge driver that shells out to `provenance compile` silently drops the other side''s record, because git invokes merge drivers before writing the incoming branch''s record YAML files into the worktree, so `compile` regenerates from only one side''s records and exits 0 anyway (verified end-to-end in the issue). A driver that merges the JSON directly can rebuild `full_graph_hash` (sha256 over the sorted id+hash concatenation per computeGraphHash) but not `active_subset_hash`, since isActiveRecord needs each record''s `status` and the manifest does not carry it. Compounding this: validateImmutability (pkg/provenance/linter.go) treats a record with no manifest entry as "pre-dates the manifest, nothing to check" unconditionally, so a hash a bad merge silently dropped is indistinguishable from a pre-manifest record — lint and check both pass with a record missing from the manifest, silently disabling its immutability check. Separately, NewCommandsWithEmbedder (pkg/provenance/commands.go) always builds the Hasher from repoRoot via NewHasher(repoRoot), never from the resolved provenance config''s own directory, so `compile -c packages/foo/.linespec.yml` writes to the same `<repoRoot>/.linespec/hash_manifest.json` as a root-level compile and clobbers it with only that package''s records instead of getting a manifest of its own.'
 constraints:
@@ -11,7 +11,7 @@ constraints:
   - linespec provenance lint and linespec provenance check must report an error (not pass silently) when an implemented record has no entry in an otherwise non-empty hash manifest, so a hash a bad merge dropped becomes a CI-visible failure instead of a silently disabled immutability check. A manifest that does not exist at all (pre-manifest repos) must continue to be treated as "nothing to check yet."
   - Existing sealed-record immutability detection (the PROV-IMM content-hash-mismatch check) must continue to work unchanged for every record that does have a manifest entry — no regression to tamper detection.
   - The manifest path used by seal/compile/verify must be derived from the resolved provenance config actually in effect (respecting `-c <path>/.linespec.yml`), not unconditionally from repoRoot, so compiling one package's config in a multi-package repo does not overwrite another package's (or the root's) manifest with a partial record set.
-  - "`linespec provenance compile` on an up-to-date manifest remains a no-op (existing idempotent short-circuit in CompileManifest) for single-package repos with no config-path override."
+  - '`linespec provenance compile` on an up-to-date manifest remains a no-op (existing idempotent short-circuit in CompileManifest) for single-package repos with no config-path override.'
 affected_scope:
   - pkg/provenance/hasher.go
   - pkg/provenance/hasher_test.go
@@ -23,18 +23,15 @@ affected_scope:
   - cmd/linespec/cli.go
   - PROVENANCE_RECORDS.md
   - .gitattributes
-forbidden_scope: []
 type: bug
 extends: prov-2026-37bea46b
-supersedes: ""
-superseded_by: ""
-related: []
-sealed_at_sha: ""
+superseded_by: ''
+sealed_at_sha: ''
 associated_specs:
   - path: pkg/provenance/hash_manifest_conflict_test.go
     run_command: go test ./pkg/provenance/... -run TestIssue163 -v
   - path: pkg/provenance/hasher_test.go
-    run_command: make test # {{path}}
+    run_command: make test
 associated_traces: []
 monitors: []
 tags:


### PR DESCRIPTION
Automated edit via linespec-provenance-ui.

Changes: status: draft → open

Record: `prov-2026-3687be46`